### PR TITLE
feat(mail): add reply_to parameter to send/draft tools

### DIFF
--- a/src/outlook_mcp/server.py
+++ b/src/outlook_mcp/server.py
@@ -173,13 +173,19 @@ async def outlook_send_message(
     importance: str = "normal",
     sensitivity: str = "normal",
     request_read_receipt: bool = False,
+    reply_to: list[str] | None = None,
 ) -> dict:
-    """Send email with recipients, CC, BCC, HTML support, importance, and sensitivity."""
+    """Send email with recipients, CC, BCC, HTML support, importance, and sensitivity.
+
+    Pass ``reply_to`` to have recipient replies routed to addresses other than
+    the authenticated sender (e.g. a shared team alias).
+    """
     client = _get_graph_client(ctx)
     config = _get_config(ctx)
     return await mail_write.send_message(
         client.sdk_client, to, subject, body, cc, bcc, is_html, importance,
         sensitivity=sensitivity, request_read_receipt=request_read_receipt,
+        reply_to=reply_to,
         config=config,
     )
 
@@ -605,12 +611,17 @@ async def outlook_create_draft(
     bcc: list[str] | None = None,
     is_html: bool = False,
     importance: str = "normal",
+    reply_to: list[str] | None = None,
 ) -> dict:
-    """Create a draft message in the Drafts folder."""
+    """Create a draft message in the Drafts folder.
+
+    Pass ``reply_to`` to pre-populate the draft's Reply-To addresses.
+    """
     client = _get_graph_client(ctx)
     config = _get_config(ctx)
     return await mail_drafts.create_draft(
         client.sdk_client, to, subject, body, cc, bcc, is_html, importance,
+        reply_to=reply_to,
         config=config,
     )
 
@@ -623,12 +634,19 @@ async def outlook_update_draft(
     body: str | None = None,
     to: list[str] | None = None,
     cc: list[str] | None = None,
+    reply_to: list[str] | None = None,
 ) -> dict:
-    """Update an existing draft message."""
+    """Update an existing draft message.
+
+    Pass ``reply_to=[...]`` to overwrite the draft's Reply-To addresses;
+    pass ``reply_to=[]`` to clear them.
+    """
     client = _get_graph_client(ctx)
     config = _get_config(ctx)
     return await mail_drafts.update_draft(
-        client.sdk_client, draft_id, subject, body, to, cc, config=config,
+        client.sdk_client, draft_id, subject, body, to, cc,
+        reply_to=reply_to,
+        config=config,
     )
 
 
@@ -683,12 +701,18 @@ async def outlook_send_with_attachments(
     bcc: list[str] | None = None,
     is_html: bool = False,
     importance: str = "normal",
+    reply_to: list[str] | None = None,
 ) -> dict:
-    """Send a message with file attachments. Handles large files automatically."""
+    """Send a message with file attachments. Handles large files automatically.
+
+    Pass ``reply_to`` to route recipient replies to a different address than
+    the authenticated sender.
+    """
     client = _get_graph_client(ctx)
     config = _get_config(ctx)
     return await mail_attachments.send_with_attachments(
         client.sdk_client, to, subject, body, attachment_paths, cc, bcc, is_html, importance,
+        reply_to=reply_to,
         config=config,
     )
 

--- a/src/outlook_mcp/tools/mail_attachments.py
+++ b/src/outlook_mcp/tools/mail_attachments.py
@@ -130,6 +130,7 @@ async def send_with_attachments(
     bcc: list[str] | None = None,
     is_html: bool = False,
     importance: str = "normal",
+    reply_to: list[str] | None = None,
     *,
     config: Config,
 ) -> dict:
@@ -144,6 +145,7 @@ async def send_with_attachments(
     validated_to = [validate_email(e) for e in to]
     validated_cc = [validate_email(e) for e in cc] if cc else []
     validated_bcc = [validate_email(e) for e in bcc] if bcc else []
+    validated_reply_to = [validate_email(e) for e in reply_to] if reply_to else []
 
     # Validate all files exist
     for path in attachment_paths:
@@ -185,6 +187,8 @@ async def send_with_attachments(
             msg.cc_recipients = [_make_recipient(e) for e in validated_cc]
         if validated_bcc:
             msg.bcc_recipients = [_make_recipient(e) for e in validated_bcc]
+        if validated_reply_to:
+            msg.reply_to = [_make_recipient(e) for e in validated_reply_to]
         importance_map = {
             "low": Importance.Low,
             "normal": Importance.Normal,

--- a/src/outlook_mcp/tools/mail_drafts.py
+++ b/src/outlook_mcp/tools/mail_drafts.py
@@ -60,6 +60,7 @@ async def create_draft(
     bcc: list[str] | None = None,
     is_html: bool = False,
     importance: str = "normal",
+    reply_to: list[str] | None = None,
     *,
     config: Config,
 ) -> dict:
@@ -74,6 +75,7 @@ async def create_draft(
     validated_to = [validate_email(e) for e in to]
     validated_cc = [validate_email(e) for e in cc] if cc else []
     validated_bcc = [validate_email(e) for e in bcc] if bcc else []
+    validated_reply_to = [validate_email(e) for e in reply_to] if reply_to else []
 
     from msgraph.generated.models.body_type import BodyType
     from msgraph.generated.models.email_address import EmailAddress
@@ -98,6 +100,8 @@ async def create_draft(
         msg.cc_recipients = [_make_recipient(e) for e in validated_cc]
     if validated_bcc:
         msg.bcc_recipients = [_make_recipient(e) for e in validated_bcc]
+    if validated_reply_to:
+        msg.reply_to = [_make_recipient(e) for e in validated_reply_to]
 
     importance_map = {
         "low": Importance.Low,
@@ -122,6 +126,7 @@ async def update_draft(
     body: str | None = None,
     to: list[str] | None = None,
     cc: list[str] | None = None,
+    reply_to: list[str] | None = None,
     *,
     config: Config,
 ) -> dict:
@@ -175,6 +180,20 @@ async def update_draft(
             return r
 
         msg.cc_recipients = [_make_cc_recipient(e) for e in validated_cc]
+
+    if reply_to is not None:
+        from msgraph.generated.models.email_address import EmailAddress
+        from msgraph.generated.models.recipient import Recipient
+
+        validated_reply_to = [validate_email(e) for e in reply_to]
+
+        def _make_reply_to_recipient(email: str) -> Recipient:
+            r = Recipient()
+            r.email_address = EmailAddress()
+            r.email_address.address = email
+            return r
+
+        msg.reply_to = [_make_reply_to_recipient(e) for e in validated_reply_to]
 
     await graph_client.me.messages.by_message_id(draft_id).patch(msg)
 

--- a/src/outlook_mcp/tools/mail_write.py
+++ b/src/outlook_mcp/tools/mail_write.py
@@ -20,6 +20,7 @@ async def send_message(
     importance: str = "normal",
     sensitivity: str = "normal",
     request_read_receipt: bool = False,
+    reply_to: list[str] | None = None,
     *,
     config: Config,
 ) -> dict:
@@ -34,6 +35,7 @@ async def send_message(
     validated_to = [validate_email(e) for e in to]
     validated_cc = [validate_email(e) for e in cc] if cc else []
     validated_bcc = [validate_email(e) for e in bcc] if bcc else []
+    validated_reply_to = [validate_email(e) for e in reply_to] if reply_to else []
 
     from msgraph.generated.models.body_type import BodyType
     from msgraph.generated.models.email_address import EmailAddress
@@ -62,6 +64,8 @@ async def send_message(
         msg.cc_recipients = [_make_recipient(e) for e in validated_cc]
     if validated_bcc:
         msg.bcc_recipients = [_make_recipient(e) for e in validated_bcc]
+    if validated_reply_to:
+        msg.reply_to = [_make_recipient(e) for e in validated_reply_to]
 
     importance_map = {
         "low": Importance.Low,

--- a/tests/test_mail_attachments.py
+++ b/tests/test_mail_attachments.py
@@ -178,6 +178,46 @@ class TestSendWithAttachments:
         assert result["attachment_count"] == 1
         mock_client.me.send_mail.post.assert_called_once()
 
+    async def test_send_sets_reply_to(self, tmp_path):
+        """send_with_attachments propagates reply_to into the Message."""
+        test_file = tmp_path / "small.txt"
+        test_file.write_bytes(b"hello world")
+
+        mock_client = MagicMock()
+        mock_client.me.send_mail.post = AsyncMock()
+
+        await send_with_attachments(
+            mock_client,
+            to=["test@example.com"],
+            subject="Test",
+            body="See attached",
+            attachment_paths=[str(test_file)],
+            reply_to=["alias@test.com"],
+            config=_CFG,
+        )
+
+        request_body = mock_client.me.send_mail.post.call_args.args[0]
+        reply_to_list = request_body.message.reply_to
+        assert reply_to_list is not None
+        assert [r.email_address.address for r in reply_to_list] == ["alias@test.com"]
+
+    async def test_send_rejects_invalid_reply_to(self, tmp_path):
+        """send_with_attachments validates reply_to addresses."""
+        test_file = tmp_path / "small.txt"
+        test_file.write_bytes(b"hello")
+
+        mock_client = MagicMock()
+        with pytest.raises(ValueError):
+            await send_with_attachments(
+                mock_client,
+                to=["test@example.com"],
+                subject="Test",
+                body="Hi",
+                attachment_paths=[str(test_file)],
+                reply_to=["not-an-email"],
+                config=_CFG,
+            )
+
     async def test_send_raises_read_only(self, tmp_path):
         """send_with_attachments raises ReadOnlyError in read-only mode."""
         test_file = tmp_path / "small.txt"

--- a/tests/test_mail_drafts.py
+++ b/tests/test_mail_drafts.py
@@ -163,6 +163,40 @@ class TestCreateDraft:
                 config=_CFG_RO,
             )
 
+    async def test_create_draft_sets_reply_to(self):
+        """create_draft populates Message.reply_to when reply_to is provided."""
+        created_msg = MagicMock()
+        created_msg.id = "AAMkDraftReplyTo="
+
+        client = MagicMock()
+        client.me.messages.post = AsyncMock(return_value=created_msg)
+
+        await create_draft(
+            client,
+            to=["to@test.com"],
+            subject="Reply-To Test",
+            body="Hello",
+            reply_to=["alias@test.com"],
+            config=_CFG,
+        )
+
+        posted_msg = client.me.messages.post.call_args.args[0]
+        assert posted_msg.reply_to is not None
+        assert [r.email_address.address for r in posted_msg.reply_to] == ["alias@test.com"]
+
+    async def test_create_draft_rejects_invalid_reply_to(self):
+        """create_draft rejects malformed reply_to addresses."""
+        client = MagicMock()
+        with pytest.raises(ValueError):
+            await create_draft(
+                client,
+                to=["to@test.com"],
+                subject="Test",
+                body="Hello",
+                reply_to=["bogus"],
+                config=_CFG,
+            )
+
 
 class TestUpdateDraft:
     async def test_update_draft_patches_partial(self):
@@ -204,6 +238,57 @@ class TestUpdateDraft:
                 draft_id="AAMkAG123=",
                 subject="Test",
                 config=_CFG_RO,
+            )
+
+    async def test_update_draft_patches_reply_to(self):
+        """update_draft sets reply_to on the PATCH payload when provided."""
+        msg_builder = MagicMock()
+        msg_builder.patch = AsyncMock()
+
+        client = MagicMock()
+        client.me.messages.by_message_id = MagicMock(return_value=msg_builder)
+
+        await update_draft(
+            client,
+            draft_id="AAMkAG123=",
+            reply_to=["alias@test.com", "team@test.com"],
+            config=_CFG,
+        )
+
+        patched_msg = msg_builder.patch.call_args.args[0]
+        assert patched_msg.reply_to is not None
+        assert [r.email_address.address for r in patched_msg.reply_to] == [
+            "alias@test.com",
+            "team@test.com",
+        ]
+
+    async def test_update_draft_clears_reply_to_with_empty_list(self):
+        """update_draft with reply_to=[] clears the field on the draft."""
+        msg_builder = MagicMock()
+        msg_builder.patch = AsyncMock()
+
+        client = MagicMock()
+        client.me.messages.by_message_id = MagicMock(return_value=msg_builder)
+
+        await update_draft(
+            client,
+            draft_id="AAMkAG123=",
+            reply_to=[],
+            config=_CFG,
+        )
+
+        patched_msg = msg_builder.patch.call_args.args[0]
+        assert patched_msg.reply_to == []
+
+    async def test_update_draft_rejects_invalid_reply_to(self):
+        """update_draft rejects malformed reply_to addresses."""
+        client = MagicMock()
+        with pytest.raises(ValueError):
+            await update_draft(
+                client,
+                draft_id="AAMkAG123=",
+                reply_to=["bogus"],
+                config=_CFG,
             )
 
 

--- a/tests/test_mail_write.py
+++ b/tests/test_mail_write.py
@@ -58,6 +58,50 @@ class TestSendMessage:
         assert result["status"] == "sent"
         mock_client.me.send_mail.post.assert_called_once()
 
+    async def test_send_sets_reply_to(self):
+        """send_message populates Message.reply_to when reply_to is provided."""
+        mock_client = AsyncMock()
+        mock_client.me.send_mail.post = AsyncMock()
+        result = await send_message(
+            mock_client,
+            to=["to@test.com"],
+            subject="Test",
+            body="Hello",
+            reply_to=["alias@test.com", "team@test.com"],
+            config=_CFG,
+        )
+        assert result["status"] == "sent"
+        request_body = mock_client.me.send_mail.post.call_args.args[0]
+        reply_to_list = request_body.message.reply_to
+        assert reply_to_list is not None
+        assert [r.email_address.address for r in reply_to_list] == [
+            "alias@test.com",
+            "team@test.com",
+        ]
+
+    async def test_send_no_reply_to_leaves_field_unset(self):
+        """send_message does not set Message.reply_to when reply_to is omitted."""
+        mock_client = AsyncMock()
+        mock_client.me.send_mail.post = AsyncMock()
+        await send_message(
+            mock_client, to=["to@test.com"], subject="Test", body="Hello", config=_CFG,
+        )
+        request_body = mock_client.me.send_mail.post.call_args.args[0]
+        assert request_body.message.reply_to is None
+
+    async def test_send_rejects_invalid_reply_to(self):
+        """send_message rejects malformed reply_to addresses."""
+        mock_client = AsyncMock()
+        with pytest.raises(ValueError):
+            await send_message(
+                mock_client,
+                to=["to@test.com"],
+                subject="Test",
+                body="Hello",
+                reply_to=["not-an-email"],
+                config=_CFG,
+            )
+
 
 class TestReply:
     async def test_reply_calls_reply_post(self):


### PR DESCRIPTION
## Summary

Adds an optional `reply_to: list[str] | None` parameter to four tools so MCP clients can route recipient replies to addresses other than the authenticated sender:

- `outlook_send_message`
- `outlook_send_with_attachments`
- `outlook_create_draft`
- `outlook_update_draft`

The parameter maps 1:1 to Graph's [`message.replyTo`](https://learn.microsoft.com/en-us/graph/api/resources/message?view=graph-rest-1.0#properties) property. Addresses are validated through the existing `validate_email` pipeline. On `outlook_update_draft`, passing `reply_to=[]` clears the field; omitting the parameter leaves it untouched (consistent with how `cc`/`to` already behave there).

## Motivation

The server already supports CC, BCC, importance, sensitivity, and read-receipts on the send path but not Reply-To. Common use cases that need this:

- Sending from an automation identity but routing replies to a shared team alias (support@, sales@)
- Agents that send on a user's behalf from a relay account and need responses to land in the original mailbox
- Newsletter/notification workflows where the From is a no-reply-style address but the team wants replies somewhere

Today these flows have to fall back to `outlook_create_draft` + manual edit in Outlook before `outlook_send_draft`, which defeats the point of an MCP-driven send.

## Changes

| File | Change |
|---|---|
| `src/outlook_mcp/tools/mail_write.py` | `send_message`: accept and set `msg.reply_to` |
| `src/outlook_mcp/tools/mail_attachments.py` | `send_with_attachments`: accept and set `msg.reply_to` (inline-path) |
| `src/outlook_mcp/tools/mail_drafts.py` | `create_draft`, `update_draft`: accept and set `msg.reply_to`; empty-list semantics on update |
| `src/outlook_mcp/server.py` | Thread the parameter through the four `@mcp.tool()` wrappers; note it in docstrings |
| `tests/test_mail_write.py` | 3 tests: populates `reply_to`, omitted → `None`, validates emails |
| `tests/test_mail_drafts.py` | 5 tests: create sets `reply_to`, create rejects invalid, update patches `reply_to`, update `reply_to=[]` clears, update rejects invalid |
| `tests/test_mail_attachments.py` | 2 tests: inline-path `reply_to`, validates emails |

No changes to the tools' existing signature positions — `reply_to` is appended as a keyword arg with a `None` default, so existing callers are untouched.

## Test plan

- [x] `uv run pytest tests/test_mail_write.py tests/test_mail_drafts.py tests/test_mail_attachments.py` — 50 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] Full suite: new tests all pass; 11 pre-existing failures on `main` (calendar_read / config / pagination_integration) are unrelated to this change — verified by running the same suite on the base branch before applying this diff
- [ ] Manual end-to-end smoke test against a real Outlook.com mailbox is not included; happy to run one if you'd like before merge