### PR TITLE
feat(mail): add attach_to_draft and remove_draft_attachment tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Give your AI agent full Outlook access. Example prompts that just work:
 - *"Draft a reply to the last message from my sister saying I'll call her this weekend."*
 - *"Move all newsletter and promotional email from this week to a 'Read Later' folder — batch 20 at a time."*
 
-The server exposes 52 discrete tools so the agent can compose its own workflow — read, triage, write, schedule, track tasks — without hardcoded macros.
+The server exposes 54 discrete tools so the agent can compose its own workflow — read, triage, write, schedule, track tasks — without hardcoded macros.
 
 ## Works With
 
@@ -42,7 +42,7 @@ Listed on the [official MCP Registry](https://registry.modelcontextprotocol.io/v
 
 ## Features
 
-**52 tools** across 13 categories:
+**54 tools** across 13 categories:
 
 - **Auth (1)** -- auth status check (login is via CLI)
 - **Mail Read (4)** -- list inbox (with Focused Inbox filter), read message, search (KQL), list folders
@@ -53,7 +53,7 @@ Listed on the [official MCP Registry](https://registry.modelcontextprotocol.io/v
 - **Contacts (6)** -- list, search, get, create, update, delete
 - **To Do (6)** -- list task lists, list/create/update/complete/delete tasks
 - **Drafts (5)** -- list, create, update, send, delete
-- **Attachments (3)** -- list, download, send-with-attachments
+- **Attachments (5)** -- list, download, send-with-attachments, attach-to-draft, remove-draft-attachment
 - **Folder Management (3)** -- create, rename, delete mail folders
 - **Threading and Batch (3)** -- list thread, copy message, batch triage
 - **User and Admin (6)** -- whoami, list calendars, list categories, mail tips, accounts
@@ -294,6 +294,8 @@ uv run outlook-mcp serve    # Start MCP server (default, used by OpenClaw/Claude
 | `outlook_list_attachments` | List attachments on a message. |
 | `outlook_download_attachment` | Download attachment (base64 or save to file). |
 | `outlook_send_with_attachments` | Send message with file attachments (auto upload session for >3MB). |
+| `outlook_attach_to_draft` | Add attachments to an existing draft (auto upload session for >3MB). |
+| `outlook_remove_draft_attachment` | Remove a single attachment from a draft. |
 
 ### Folder Management
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: outlook-mcp
-description: MCP server for Microsoft Outlook personal accounts. 52 tools — mail, calendar, contacts, to-do, drafts, attachments, folders, threading, batch ops, Focused Inbox.
+description: MCP server for Microsoft Outlook personal accounts. 54 tools — mail, calendar, contacts, to-do, drafts, attachments, folders, threading, batch ops, Focused Inbox.
 homepage: https://github.com/mpalermiti/outlook-mcp
 metadata:
   openclaw:
@@ -111,6 +111,8 @@ Provides AI agents with full access to mail, calendar, contacts, and tasks via M
 - `outlook_list_attachments` — List on a message
 - `outlook_download_attachment` — Download (base64 or save to file)
 - `outlook_send_with_attachments` — Send with files (auto upload session for >3MB)
+- `outlook_attach_to_draft` — Add attachments to an existing draft (auto upload session for >3MB)
+- `outlook_remove_draft_attachment` — Remove a single attachment from a draft
 
 ### Folder Management
 - `outlook_create_folder` — Create (top-level or nested)

--- a/src/outlook_mcp/server.py
+++ b/src/outlook_mcp/server.py
@@ -693,6 +693,38 @@ async def outlook_send_with_attachments(
     )
 
 
+@mcp.tool()
+async def outlook_attach_to_draft(
+    ctx: Context,
+    draft_id: str,
+    attachment_paths: list[str],
+) -> dict:
+    """Add attachments to an existing draft. Handles large files automatically.
+
+    Returns the new attachment IDs so the caller can remove individual
+    attachments later via ``outlook_remove_draft_attachment``.
+    """
+    client = _get_graph_client(ctx)
+    config = _get_config(ctx)
+    return await mail_attachments.attach_to_draft(
+        client.sdk_client, draft_id, attachment_paths, config=config,
+    )
+
+
+@mcp.tool()
+async def outlook_remove_draft_attachment(
+    ctx: Context,
+    draft_id: str,
+    attachment_id: str,
+) -> dict:
+    """Remove a single attachment from a draft message."""
+    client = _get_graph_client(ctx)
+    config = _get_config(ctx)
+    return await mail_attachments.remove_draft_attachment(
+        client.sdk_client, draft_id, attachment_id, config=config,
+    )
+
+
 # ── Mail Folder Management Tools ─────────────────────
 
 

--- a/src/outlook_mcp/tools/mail_attachments.py
+++ b/src/outlook_mcp/tools/mail_attachments.py
@@ -1,4 +1,4 @@
-"""Mail attachment tools: list, download, send with attachments."""
+"""Mail attachment tools: list, download, send / attach to drafts."""
 
 from __future__ import annotations
 
@@ -8,7 +8,11 @@ import os
 from typing import Any
 
 from outlook_mcp.config import Config
-from outlook_mcp.permissions import CATEGORY_MAIL_SEND, check_permission
+from outlook_mcp.permissions import (
+    CATEGORY_MAIL_DRAFTS,
+    CATEGORY_MAIL_SEND,
+    check_permission,
+)
 from outlook_mcp.validation import validate_email, validate_graph_id
 
 # 3MB threshold — files above this use upload sessions
@@ -22,6 +26,20 @@ def _validate_save_path(save_path: str) -> str:
     if ".." in save_path:
         raise ValueError(f"Path traversal not allowed in save_path: {save_path}")
     return save_path
+
+
+def _make_inline_attachment(file_path: str) -> Any:
+    """Build a FileAttachment SDK object from a local file (<=3MB path)."""
+    from msgraph.generated.models.file_attachment import FileAttachment
+
+    att = FileAttachment()
+    att.name = os.path.basename(file_path)
+    with open(file_path, "rb") as f:
+        att.content_bytes = f.read()
+    content_type, _ = mimetypes.guess_type(file_path)
+    att.content_type = content_type or "application/octet-stream"
+    att.odata_type = "#microsoft.graph.fileAttachment"
+    return att
 
 
 async def list_attachments(
@@ -162,7 +180,6 @@ async def send_with_attachments(
 
     from msgraph.generated.models.body_type import BodyType
     from msgraph.generated.models.email_address import EmailAddress
-    from msgraph.generated.models.file_attachment import FileAttachment
     from msgraph.generated.models.importance import Importance
     from msgraph.generated.models.item_body import ItemBody
     from msgraph.generated.models.message import Message
@@ -192,16 +209,6 @@ async def send_with_attachments(
         }
         msg.importance = importance_map.get(importance, Importance.Normal)
         return msg
-
-    def _make_inline_attachment(file_path: str) -> FileAttachment:
-        att = FileAttachment()
-        att.name = os.path.basename(file_path)
-        with open(file_path, "rb") as f:
-            att.content_bytes = f.read()
-        content_type, _ = mimetypes.guess_type(file_path)
-        att.content_type = content_type or "application/octet-stream"
-        att.odata_type = "#microsoft.graph.fileAttachment"
-        return att
 
     if not large_files:
         # All small — send inline via sendMail
@@ -257,4 +264,106 @@ async def send_with_attachments(
     return {
         "status": "sent",
         "attachment_count": len(attachment_paths),
+    }
+
+
+async def attach_to_draft(
+    graph_client: Any,
+    draft_id: str,
+    attachment_paths: list[str],
+    *,
+    config: Config,
+) -> dict:
+    """Add one or more attachments to an existing draft message.
+
+    For files under 3MB: POST a FileAttachment directly.
+    For files over 3MB: createUploadSession + chunked upload.
+
+    Returns the new attachment IDs so callers can reference or
+    remove individual attachments later.
+    """
+    check_permission(config, CATEGORY_MAIL_DRAFTS, "outlook_attach_to_draft")
+    draft_id = validate_graph_id(draft_id)
+
+    # Validate all files exist before any API call
+    for path in attachment_paths:
+        if not os.path.isfile(path):
+            raise FileNotFoundError(f"Attachment file not found: {path}")
+
+    # Partition files into small (inline) and large (upload session)
+    small_files: list[str] = []
+    large_files: list[tuple[str, int]] = []
+    for path in attachment_paths:
+        file_size = os.path.getsize(path)
+        if file_size > _LARGE_FILE_THRESHOLD:
+            large_files.append((path, file_size))
+        else:
+            small_files.append(path)
+
+    attachment_ids: list[str] = []
+    msg_builder = graph_client.me.messages.by_message_id(draft_id)
+
+    # Small files — POST each as an inline FileAttachment
+    for file_path in small_files:
+        att = _make_inline_attachment(file_path)
+        created = await msg_builder.attachments.post(att)
+        if created is not None and getattr(created, "id", None):
+            attachment_ids.append(created.id)
+
+    # Large files — upload session
+    if large_files:
+        from msgraph.generated.models.attachment_item import AttachmentItem
+        from msgraph.generated.models.attachment_type import AttachmentType
+        from msgraph.generated.users.item.messages.item.attachments.create_upload_session.create_upload_session_post_request_body import (  # noqa: E501
+            CreateUploadSessionPostRequestBody,
+        )
+
+        for file_path, file_size in large_files:
+            content_type, _ = mimetypes.guess_type(file_path)
+            att_item = AttachmentItem()
+            att_item.attachment_type = AttachmentType.File
+            att_item.name = os.path.basename(file_path)
+            att_item.size = file_size
+            att_item.content_type = content_type or "application/octet-stream"
+
+            upload_body = CreateUploadSessionPostRequestBody()
+            upload_body.attachment_item = att_item
+
+            session = await msg_builder.attachments.create_upload_session.post(upload_body)
+            await _upload_large_file(session.upload_url, file_path, file_size)
+
+    return {
+        "status": "attached",
+        "draft_id": draft_id,
+        "attachment_count": len(attachment_paths),
+        "attachment_ids": attachment_ids,
+    }
+
+
+async def remove_draft_attachment(
+    graph_client: Any,
+    draft_id: str,
+    attachment_id: str,
+    *,
+    config: Config,
+) -> dict:
+    """Remove a single attachment from a draft message.
+
+    DELETE /me/messages/{draft_id}/attachments/{attachment_id}.
+    Only useful on drafts — sent messages are immutable.
+    """
+    check_permission(config, CATEGORY_MAIL_DRAFTS, "outlook_remove_draft_attachment")
+    draft_id = validate_graph_id(draft_id)
+    attachment_id = validate_graph_id(attachment_id)
+
+    await (
+        graph_client.me.messages.by_message_id(draft_id)
+        .attachments.by_attachment_id(attachment_id)
+        .delete()
+    )
+
+    return {
+        "status": "removed",
+        "draft_id": draft_id,
+        "attachment_id": attachment_id,
     }

--- a/tests/test_mail_attachments.py
+++ b/tests/test_mail_attachments.py
@@ -9,8 +9,10 @@ import pytest
 from outlook_mcp.config import Config
 from outlook_mcp.errors import ReadOnlyError
 from outlook_mcp.tools.mail_attachments import (
+    attach_to_draft,
     download_attachment,
     list_attachments,
+    remove_draft_attachment,
     send_with_attachments,
 )
 
@@ -277,3 +279,199 @@ class TestSendWithAttachments:
         )
         assert result["status"] == "sent"
         mock_client.me.send_mail.post.assert_called_once()
+
+
+class TestAttachToDraft:
+    async def test_attach_small_file_posts_inline(self, tmp_path):
+        """attach_to_draft POSTs small files as inline FileAttachments."""
+        small_file = tmp_path / "note.txt"
+        small_file.write_bytes(b"hello world")
+
+        created_att = MagicMock()
+        created_att.id = "att_new_1"
+
+        mock_client = MagicMock()
+        mock_builder = mock_client.me.messages.by_message_id.return_value
+        mock_builder.attachments.post = AsyncMock(return_value=created_att)
+
+        result = await attach_to_draft(
+            mock_client,
+            draft_id="AAMkAG123=",
+            attachment_paths=[str(small_file)],
+            config=_CFG,
+        )
+
+        assert result["status"] == "attached"
+        assert result["draft_id"] == "AAMkAG123="
+        assert result["attachment_count"] == 1
+        assert result["attachment_ids"] == ["att_new_1"]
+        mock_client.me.messages.by_message_id.assert_called_with("AAMkAG123=")
+        mock_builder.attachments.post.assert_called_once()
+
+    async def test_attach_large_file_uses_upload_session(self, tmp_path):
+        """attach_to_draft uses createUploadSession for files over 3MB."""
+        large_file = tmp_path / "big.bin"
+        large_file.write_bytes(b"x" * (3 * 1024 * 1024 + 1))
+
+        mock_session = MagicMock()
+        mock_session.upload_url = "https://graph.microsoft.com/upload/session"
+
+        mock_client = MagicMock()
+        mock_builder = mock_client.me.messages.by_message_id.return_value
+        mock_builder.attachments.create_upload_session.post = AsyncMock(
+            return_value=mock_session
+        )
+
+        with patch(
+            "outlook_mcp.tools.mail_attachments._upload_large_file", new_callable=AsyncMock
+        ) as mock_upload:
+            result = await attach_to_draft(
+                mock_client,
+                draft_id="AAMkAG123=",
+                attachment_paths=[str(large_file)],
+                config=_CFG,
+            )
+
+        assert result["status"] == "attached"
+        assert result["attachment_count"] == 1
+        mock_builder.attachments.create_upload_session.post.assert_called_once()
+        mock_upload.assert_called_once()
+
+    async def test_attach_mixed_sizes(self, tmp_path):
+        """attach_to_draft handles a mix of small and large files in one call."""
+        small = tmp_path / "small.txt"
+        small.write_bytes(b"tiny")
+        big = tmp_path / "big.bin"
+        big.write_bytes(b"x" * (3 * 1024 * 1024 + 1))
+
+        created_att = MagicMock()
+        created_att.id = "att_small_1"
+
+        mock_session = MagicMock()
+        mock_session.upload_url = "https://graph.microsoft.com/upload/session"
+
+        mock_client = MagicMock()
+        mock_builder = mock_client.me.messages.by_message_id.return_value
+        mock_builder.attachments.post = AsyncMock(return_value=created_att)
+        mock_builder.attachments.create_upload_session.post = AsyncMock(
+            return_value=mock_session
+        )
+
+        with patch(
+            "outlook_mcp.tools.mail_attachments._upload_large_file", new_callable=AsyncMock
+        ):
+            result = await attach_to_draft(
+                mock_client,
+                draft_id="AAMkAG123=",
+                attachment_paths=[str(small), str(big)],
+                config=_CFG,
+            )
+
+        assert result["attachment_count"] == 2
+        assert result["attachment_ids"] == ["att_small_1"]
+        mock_builder.attachments.post.assert_called_once()
+        mock_builder.attachments.create_upload_session.post.assert_called_once()
+
+    async def test_attach_validates_draft_id(self, tmp_path):
+        """attach_to_draft rejects invalid draft IDs."""
+        f = tmp_path / "x.txt"
+        f.write_bytes(b"x")
+        mock_client = MagicMock()
+        with pytest.raises(ValueError, match="invalid characters"):
+            await attach_to_draft(
+                mock_client,
+                draft_id="bad id with spaces!",
+                attachment_paths=[str(f)],
+                config=_CFG,
+            )
+
+    async def test_attach_raises_on_missing_file(self):
+        """attach_to_draft raises FileNotFoundError when a path does not exist."""
+        mock_client = MagicMock()
+        with pytest.raises(FileNotFoundError):
+            await attach_to_draft(
+                mock_client,
+                draft_id="AAMkAG123=",
+                attachment_paths=["/nonexistent/file.txt"],
+                config=_CFG,
+            )
+
+    async def test_attach_raises_read_only(self, tmp_path):
+        """attach_to_draft raises ReadOnlyError in read-only mode."""
+        f = tmp_path / "x.txt"
+        f.write_bytes(b"x")
+        mock_client = MagicMock()
+        with pytest.raises(ReadOnlyError):
+            await attach_to_draft(
+                mock_client,
+                draft_id="AAMkAG123=",
+                attachment_paths=[str(f)],
+                config=_CFG_RO,
+            )
+
+    async def test_attach_empty_list_is_noop(self):
+        """attach_to_draft with empty attachment_paths makes no API calls."""
+        mock_client = MagicMock()
+
+        result = await attach_to_draft(
+            mock_client,
+            draft_id="AAMkAG123=",
+            attachment_paths=[],
+            config=_CFG,
+        )
+
+        assert result["attachment_count"] == 0
+        assert result["attachment_ids"] == []
+        mock_client.me.messages.by_message_id.return_value.attachments.post.assert_not_called()
+
+
+class TestRemoveDraftAttachment:
+    async def test_remove_calls_delete(self):
+        """remove_draft_attachment DELETEs the attachment by ID."""
+        mock_client = MagicMock()
+        att_builder = MagicMock()
+        att_builder.delete = AsyncMock()
+        mock_client.me.messages.by_message_id.return_value.attachments.by_attachment_id.return_value = (  # noqa: E501
+            att_builder
+        )
+
+        result = await remove_draft_attachment(
+            mock_client,
+            draft_id="AAMkAG123=",
+            attachment_id="ATT456=",
+            config=_CFG,
+        )
+
+        assert result["status"] == "removed"
+        assert result["draft_id"] == "AAMkAG123="
+        assert result["attachment_id"] == "ATT456="
+        att_builder.delete.assert_called_once()
+
+    async def test_remove_validates_ids(self):
+        """remove_draft_attachment rejects invalid draft or attachment IDs."""
+        mock_client = MagicMock()
+        with pytest.raises(ValueError, match="invalid characters"):
+            await remove_draft_attachment(
+                mock_client,
+                draft_id="bad id!",
+                attachment_id="ATT=",
+                config=_CFG,
+            )
+        with pytest.raises(ValueError, match="invalid characters"):
+            await remove_draft_attachment(
+                mock_client,
+                draft_id="AAMkAG123=",
+                attachment_id="bad att!",
+                config=_CFG,
+            )
+
+    async def test_remove_raises_read_only(self):
+        """remove_draft_attachment raises ReadOnlyError in read-only mode."""
+        mock_client = MagicMock()
+        with pytest.raises(ReadOnlyError):
+            await remove_draft_attachment(
+                mock_client,
+                draft_id="AAMkAG123=",
+                attachment_id="ATT=",
+                config=_CFG_RO,
+            )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -51,10 +51,12 @@ EXPECTED_TOOLS = [
     "outlook_update_draft",
     "outlook_send_draft",
     "outlook_delete_draft",
-    # Mail attachments (3)
+    # Mail attachments (5)
     "outlook_list_attachments",
     "outlook_download_attachment",
     "outlook_send_with_attachments",
+    "outlook_attach_to_draft",
+    "outlook_remove_draft_attachment",
     # Mail folders (3)
     "outlook_create_folder",
     "outlook_rename_folder",
@@ -77,9 +79,9 @@ EXPECTED_TOOLS = [
 
 
 def test_tool_count():
-    """All 52 tools are registered (auth is CLI-only now)."""
+    """All 54 tools are registered (auth is CLI-only now)."""
     registered = set(mcp._tool_manager._tools.keys())
-    assert len(registered) == 52
+    assert len(registered) == 54
 
 
 def test_all_tools_registered():


### PR DESCRIPTION
## Summary

Adds two tools that let MCP clients edit the attachments on an existing draft:

- `outlook_attach_to_draft(draft_id, attachment_paths)` — adds one or more files to a draft. Reuses the 3 MB split from `outlook_send_with_attachments`: small files go inline via `POST /me/messages/{id}/attachments`, large files via `createUploadSession` + chunked PUT. Returns the new attachment IDs so callers can reference individual attachments later.
- `outlook_remove_draft_attachment(draft_id, attachment_id)` — `DELETE /me/messages/{draft_id}/attachments/{attachment_id}`.

## Motivation

Today the only way to put attachments on a message is the one-shot `outlook_send_with_attachments`, which commits to sending in the same call. Agent workflows that draft-then-review (draft an email, preview it in Outlook, send later via `outlook_send_draft`) had no way to include attachments — the draft was always empty on that dimension. Iterating on which files to include also required tearing down and re-creating the draft.

These two tools close that gap cleanly without duplicating logic: the inline/upload-session split is already battle-tested inside `send_with_attachments`, and `remove_draft_attachment` mirrors the existing read-side `download_attachment` on the write side.

## Design notes

- **Permission category.** Both tools are tagged `CATEGORY_MAIL_DRAFTS`, not `CATEGORY_MAIL_SEND`. A caller with draft access but not send access should still be able to edit a draft's attachments; sending remains gated by `outlook_send_draft`'s existing `CATEGORY_MAIL_SEND` check.
- **Scope.** Only drafts. Graph technically allows `POST /messages/{id}/attachments` on any message, but sent messages are immutable in practice across every client. Naming the tool `attach_to_draft` sets the right expectation and keeps the API honest.
- **Small refactor.** `_make_inline_attachment` moves from a closure inside `send_with_attachments` to module scope so both call sites share it. Behaviorally identical, verified by the existing `send_with_attachments` tests still passing.
- **Return shape.** `attach_to_draft` returns `attachment_ids` for the small-file POSTs only. The large-file upload-session path doesn't expose an attachment ID synchronously; callers can follow up with `outlook_list_attachments` if they need to address uploaded large files.

## Changes

| File | Change |
|---|---|
| `src/outlook_mcp/tools/mail_attachments.py` | Module-scope `_make_inline_attachment`; new `attach_to_draft` and `remove_draft_attachment` functions |
| `src/outlook_mcp/server.py` | Two new `@mcp.tool()` wrappers |
| `tests/test_mail_attachments.py` | 10 new tests: small-file POST, large-file upload-session, mixed sizes, ID validation, missing-file error, read-only, empty-list no-op; remove: delete path, ID validation (both), read-only |
| `tests/test_server.py` | Expected tool count 52 → 54; new tool names added |
| `README.md` | Tool count and Attachments category updated; new rows in the tool table |
| `SKILL.md` | Tool count and Attachments section updated |

## Test plan

- [x] `uv run pytest tests/test_mail_attachments.py` — 25 passed (15 pre-existing + 10 new)
- [x] `uv run pytest tests/test_server.py` — 5 passed (registry + count updated)
- [x] Full suite excluding pre-existing-failure modules: 341 passed, 6 skipped
- [x] `uv run ruff check src/ tests/` — clean
- [ ] Manual end-to-end smoke test against a real Outlook.com mailbox is not included; happy to run one if you'd like before merge

## Notes

- Independent from #3 (reply_to support) — these can be merged in either order.
- 11 pre-existing failures on `main` (calendar_read, config, pagination_integration) are unrelated to this change.