### PR TITLE
fix(contacts): use consumer Graph phone fields end-to-end (#1)

### DIFF
--- a/src/outlook_mcp/models/contacts.py
+++ b/src/outlook_mcp/models/contacts.py
@@ -23,7 +23,9 @@ class ContactDetail(BaseModel):
     last_name: str = ""
     display_name: str = ""
     email_addresses: list[dict[str, str]] = Field(default_factory=list)
-    phones: list[dict[str, str]] = Field(default_factory=list)
+    mobile_phone: str = ""
+    home_phones: list[str] = Field(default_factory=list)
+    business_phones: list[str] = Field(default_factory=list)
     company: str = ""
     title: str = ""
     department: str = ""

--- a/src/outlook_mcp/tools/contacts.py
+++ b/src/outlook_mcp/tools/contacts.py
@@ -20,6 +20,23 @@ def _clamp(value: int, low: int, high: int) -> int:
     return max(low, min(high, value))
 
 
+def _primary_phone(contact: Any) -> str:
+    """Pick the most representative phone from the consumer-Graph contact fields.
+
+    Consumer Outlook accounts expose mobilePhone (single), homePhones (list),
+    and businessPhones (list) — not the unified ``phones`` collection. Prefer
+    mobile, then first home, then first business.
+    """
+    mobile = getattr(contact, "mobile_phone", "") or ""
+    if mobile:
+        return mobile
+    for attr in ("home_phones", "business_phones"):
+        values = getattr(contact, attr, None) or []
+        if values:
+            return values[0]
+    return ""
+
+
 def _format_contact_summary(contact: Any) -> dict:
     """Convert Graph SDK contact to summary dict."""
     email = ""
@@ -27,16 +44,11 @@ def _format_contact_summary(contact: Any) -> dict:
         first_email = contact.email_addresses[0]
         email = getattr(first_email, "address", "") or ""
 
-    phone = ""
-    if contact.phones:
-        first_phone = contact.phones[0]
-        phone = getattr(first_phone, "number", "") or ""
-
     return {
         "id": contact.id,
         "display_name": sanitize_output(contact.display_name or ""),
         "email": email,
-        "phone": phone,
+        "phone": _primary_phone(contact),
         "company": sanitize_output(contact.company_name or ""),
     }
 
@@ -52,22 +64,15 @@ def _format_contact_detail(contact: Any) -> dict:
             }
         )
 
-    phones = []
-    for p in contact.phones or []:
-        phones.append(
-            {
-                "number": getattr(p, "number", "") or "",
-                "type": getattr(p, "type", "") or "",
-            }
-        )
-
     return {
         "id": contact.id,
         "first_name": sanitize_output(contact.given_name or ""),
         "last_name": sanitize_output(contact.surname or ""),
         "display_name": sanitize_output(contact.display_name or ""),
         "email_addresses": email_addresses,
-        "phones": phones,
+        "mobile_phone": getattr(contact, "mobile_phone", "") or "",
+        "home_phones": list(getattr(contact, "home_phones", None) or []),
+        "business_phones": list(getattr(contact, "business_phones", None) or []),
         "company": sanitize_output(contact.company_name or ""),
         "title": sanitize_output(contact.title or ""),
         "department": sanitize_output(getattr(contact, "department", "") or ""),
@@ -83,7 +88,10 @@ async def list_contacts(
     """List contacts with pagination."""
     query_params: dict[str, Any] = {
         "$orderby": "displayName",
-        "$select": ("id,displayName,givenName,surname,emailAddresses,phones,companyName,title"),
+        "$select": (
+            "id,displayName,givenName,surname,emailAddresses,"
+            "mobilePhone,homePhones,businessPhones,companyName,title"
+        ),
     }
     query_params = apply_pagination(query_params, count, cursor)
 
@@ -119,7 +127,10 @@ async def search_contacts(
     query_params: dict[str, Any] = {
         "$top": count,
         "$search": safe_query,
-        "$select": ("id,displayName,givenName,surname,emailAddresses,phones,companyName,title"),
+        "$select": (
+            "id,displayName,givenName,surname,emailAddresses,"
+            "mobilePhone,homePhones,businessPhones,companyName,title"
+        ),
     }
 
     from msgraph.generated.users.item.contacts.contacts_request_builder import (
@@ -174,7 +185,6 @@ async def create_contact(
 
     from msgraph.generated.models.contact import Contact
     from msgraph.generated.models.email_address import EmailAddress
-    from msgraph.generated.models.phone import Phone
 
     new_contact = Contact()
     new_contact.given_name = first_name
@@ -186,9 +196,7 @@ async def create_contact(
         ea.name = first_name
         new_contact.email_addresses = [ea]
     if phone:
-        p = Phone()
-        p.number = phone
-        new_contact.phones = [p]
+        new_contact.mobile_phone = phone
     if company:
         new_contact.company_name = company
     if title:
@@ -223,7 +231,6 @@ async def update_contact(
 
     from msgraph.generated.models.contact import Contact
     from msgraph.generated.models.email_address import EmailAddress
-    from msgraph.generated.models.phone import Phone
 
     patch_body = Contact()
     if first_name is not None:
@@ -235,9 +242,7 @@ async def update_contact(
         ea.address = email
         patch_body.email_addresses = [ea]
     if phone is not None:
-        p = Phone()
-        p.number = phone
-        patch_body.phones = [p]
+        patch_body.mobile_phone = phone
 
     await graph_client.me.contacts.by_contact_id(contact_id).patch(patch_body)
 

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -21,8 +21,16 @@ _CFG_RO = Config(client_id="test", read_only=True)
 
 
 def _make_mock_contact(**overrides):
-    """Factory for mock Graph SDK contact objects."""
-    contact = MagicMock()
+    """Factory for mock Graph SDK contact objects.
+
+    Matches the consumer Outlook contact shape: ``mobile_phone`` (single
+    string), ``home_phones`` (list[str]), ``business_phones`` (list[str]).
+    """
+    contact = MagicMock(spec=[
+        "id", "display_name", "given_name", "surname",
+        "company_name", "title", "department", "birthday",
+        "email_addresses", "mobile_phone", "home_phones", "business_phones",
+    ])
     contact.id = overrides.get("id", "contact123")
     contact.display_name = overrides.get("display_name", "John Doe")
     contact.given_name = overrides.get("given_name", "John")
@@ -37,10 +45,9 @@ def _make_mock_contact(**overrides):
     email.name = overrides.get("email_name", "John")
     contact.email_addresses = overrides.get("email_addresses", [email])
 
-    phone = MagicMock()
-    phone.number = overrides.get("phone_number", "+1234567890")
-    phone.type = overrides.get("phone_type", "mobile")
-    contact.phones = overrides.get("phones", [phone])
+    contact.mobile_phone = overrides.get("mobile_phone", "+1234567890")
+    contact.home_phones = overrides.get("home_phones", [])
+    contact.business_phones = overrides.get("business_phones", [])
 
     return contact
 
@@ -77,6 +84,38 @@ class TestListContacts:
         assert result["contacts"][0]["email"] == "john@test.com"
         assert result["contacts"][0]["phone"] == "+1234567890"
         assert result["contacts"][0]["company"] == "Acme"
+
+    async def test_list_select_uses_consumer_phone_fields(self):
+        """list_contacts $select must use mobilePhone/homePhones/businessPhones,
+        not the unsupported ``phones`` aggregate (Bug #1)."""
+        mock_client = _make_contacts_mock([])
+        await list_contacts(mock_client)
+
+        call_kwargs = mock_client.me.contacts.get.call_args
+        select = call_kwargs.kwargs["request_configuration"].query_parameters.select
+        select_str = ",".join(select) if isinstance(select, list) else select
+        assert "phones" not in select_str.split(",")
+        assert "mobilePhone" in select_str
+        assert "homePhones" in select_str
+        assert "businessPhones" in select_str
+
+    async def test_list_summary_falls_back_to_home_phone(self):
+        """When mobile_phone is empty, summary falls back to first home phone."""
+        contact = _make_mock_contact(mobile_phone="", home_phones=["+15551112222"])
+        mock_client = _make_contacts_mock([contact])
+
+        result = await list_contacts(mock_client)
+        assert result["contacts"][0]["phone"] == "+15551112222"
+
+    async def test_list_summary_falls_back_to_business_phone(self):
+        """When mobile and home are empty, falls back to first business phone."""
+        contact = _make_mock_contact(
+            mobile_phone="", home_phones=[], business_phones=["+15553334444"],
+        )
+        mock_client = _make_contacts_mock([contact])
+
+        result = await list_contacts(mock_client)
+        assert result["contacts"][0]["phone"] == "+15553334444"
 
     async def test_list_with_cursor(self):
         """list_contacts passes cursor to pagination."""
@@ -129,11 +168,27 @@ class TestSearchContacts:
         assert result["count"] == 1
         assert result["contacts"][0]["display_name"] == "John Doe"
 
+    async def test_search_select_uses_consumer_phone_fields(self):
+        """search_contacts $select must use consumer phone fields (Bug #1)."""
+        mock_client = _make_contacts_mock([])
+        await search_contacts(mock_client, query="John")
+
+        call_kwargs = mock_client.me.contacts.get.call_args
+        select = call_kwargs.kwargs["request_configuration"].query_parameters.select
+        select_str = ",".join(select) if isinstance(select, list) else select
+        assert "phones" not in select_str.split(",")
+        assert "mobilePhone" in select_str
+        assert "homePhones" in select_str
+        assert "businessPhones" in select_str
+
 
 class TestGetContact:
     async def test_get_returns_full_detail(self):
-        """get_contact returns full contact detail."""
-        mock_contact = _make_mock_contact()
+        """get_contact returns full contact detail using consumer phone fields."""
+        mock_contact = _make_mock_contact(
+            home_phones=["+15551112222"],
+            business_phones=["+15553334444"],
+        )
         mock_client = _make_contact_by_id_mock(mock_contact)
 
         result = await get_contact(mock_client, "contact123")
@@ -145,8 +200,22 @@ class TestGetContact:
         assert result["title"] == "Engineer"
         assert len(result["email_addresses"]) == 1
         assert result["email_addresses"][0]["address"] == "john@test.com"
-        assert len(result["phones"]) == 1
-        assert result["phones"][0]["number"] == "+1234567890"
+        assert result["mobile_phone"] == "+1234567890"
+        assert result["home_phones"] == ["+15551112222"]
+        assert result["business_phones"] == ["+15553334444"]
+        assert "phones" not in result, "old aggregate 'phones' field must not appear"
+
+    async def test_get_handles_empty_phone_fields(self):
+        """get_contact returns empty defaults when phone fields are missing."""
+        mock_contact = _make_mock_contact(
+            mobile_phone="", home_phones=[], business_phones=[],
+        )
+        mock_client = _make_contact_by_id_mock(mock_contact)
+
+        result = await get_contact(mock_client, "contact123")
+        assert result["mobile_phone"] == ""
+        assert result["home_phones"] == []
+        assert result["business_phones"] == []
 
     async def test_get_validates_id(self):
         """get_contact rejects invalid contact IDs."""
@@ -175,6 +244,21 @@ class TestCreateContact:
         assert result["status"] == "created"
         assert result["id"] == "contact123"
         mock_client.me.contacts.post.assert_called_once()
+
+    async def test_create_contact_writes_mobile_phone_not_phones(self):
+        """create_contact must set mobile_phone (not the unsupported 'phones'
+        collection) on consumer Graph (Bug #1)."""
+        mock_client = MagicMock()
+        mock_client.me.contacts.post = AsyncMock(return_value=_make_mock_contact())
+
+        await create_contact(
+            mock_client, first_name="John", phone="+1234567890", config=_CFG,
+        )
+
+        payload = mock_client.me.contacts.post.call_args.args[0]
+        assert payload.mobile_phone == "+1234567890"
+        # The unsupported 'phones' aggregate must not be set
+        assert getattr(payload, "phones", None) is None
 
     async def test_create_validates_email(self):
         """create_contact rejects invalid email."""
@@ -212,6 +296,18 @@ class TestUpdateContact:
         # Verify patch was called
         contact_obj = mock_client.me.contacts.by_contact_id.return_value
         contact_obj.patch.assert_called_once()
+
+    async def test_update_writes_mobile_phone_not_phones(self):
+        """update_contact must set mobile_phone (not 'phones') on consumer Graph."""
+        mock_client = _make_contact_by_id_mock(_make_mock_contact())
+
+        await update_contact(
+            mock_client, contact_id="contact123", phone="+19998887777", config=_CFG,
+        )
+        contact_obj = mock_client.me.contacts.by_contact_id.return_value
+        payload = contact_obj.patch.call_args.args[0]
+        assert payload.mobile_phone == "+19998887777"
+        assert getattr(payload, "phones", None) is None
 
     async def test_update_validates_id(self):
         """update_contact rejects invalid contact IDs."""


### PR DESCRIPTION
## Summary

Closes #1.

The consumer Outlook (Outlook.com / Hotmail) Graph contacts endpoint does not expose the unified `phones` aggregate property — only `mobilePhone` (single string), `homePhones` (list[str]), and `businessPhones` (list[str]). `outlook_list_contacts` and `outlook_search_contacts` were sending `phones` in `\$select` and getting back a 400.

The reporter's proposed patch (just remove `phones` from `\$select`) would have unblocked list/search but **silently dropped phone data** from the results and **left the same bug in place on the write side** — `create_contact` and `update_contact` set `new_contact.phones = [Phone()]`, which is the same unsupported property under a different verb. Going for the full migration so consumer-account contacts actually work end-to-end.

## Changes

### Reads
- `\$select` in list/search now requests `mobilePhone,homePhones,businessPhones` (drops the unsupported `phones`).
- `_format_contact_summary` keeps the top-level `phone` string field (callers depend on the shape) but populates it via a new `_primary_phone()` helper that picks mobile → first home → first business.
- `_format_contact_detail` now returns three explicit fields — `mobile_phone`, `home_phones`, `business_phones` — replacing the broken `phones: [{number, type}]` shape that was always empty on consumer accounts anyway.

### Writes
- `create_contact` and `update_contact` set `new_contact.mobile_phone = phone` on the single `phone` argument (was setting the unsupported `phones=[Phone()]` collection).
- The `Phone` SDK import is removed; no longer needed.

### Public API impact
- **Tool inputs unchanged.** `outlook_create_contact(phone=...)` and `outlook_update_contact(phone=...)` still take a single phone string. Mapping it to the user's `mobilePhone` is the cleanest semantic for a single-phone parameter.
- **Tool outputs change shape on `outlook_get_contact`:** `phones: [...]` is gone, replaced by `mobile_phone: str`, `home_phones: list[str]`, `business_phones: list[str]`. Strictly speaking this is a breaking response-shape change, but the old shape was always an empty list on consumer accounts, so any caller that assumed it worked was already getting nothing.
- Summaries (`outlook_list_contacts`, `outlook_search_contacts`) keep `phone: str` semantically — same field, now correctly populated.

`src/outlook_mcp/models/contacts.py` Pydantic models updated to match.

## Test plan

- [x] `uv run pytest tests/test_contacts.py` — **24 passed** (17 pre-existing + 7 new)
- [x] `uv run pytest` — **403 passed, 6 skipped** (full suite green; no regressions)
- [x] `uv run ruff check src/ tests/` — clean
- [ ] Live verification against a real Outlook.com mailbox is not included; reporter (@waynegault) can confirm `outlook_list_contacts`, `outlook_get_contact`, and `outlook_create_contact phone=...` end-to-end after merge

## Why the new tests matter

New assertions cover the exact regression vectors that allowed the bug to ship:
- `\$select` for list/search **must not** include `phones` and **must** include the three consumer fields
- Summary `phone` field falls back through mobile → home → business correctly
- `create_contact` / `update_contact` set `mobile_phone` on the SDK payload (and never set the unsupported `phones` collection)

Generated with [Claude Code](https://claude.com/claude-code)