### PR TITLE
fix: allow unencrypted token cache fallback

### DIFF
--- a/src/outlook_mcp/auth.py
+++ b/src/outlook_mcp/auth.py
@@ -93,7 +93,10 @@ class AuthManager:
         auth_record: AuthenticationRecord | None = None,
     ) -> DeviceCodeCredential:
         """Create a DeviceCodeCredential with persistent cache."""
-        cache_options = TokenCachePersistenceOptions(name=CACHE_NAME)
+        cache_options = TokenCachePersistenceOptions(
+            name=CACHE_NAME,
+            allow_unencrypted_storage=True,
+        )
         kwargs = {
             "client_id": self.config.client_id,
             "tenant_id": self.config.tenant_id,


### PR DESCRIPTION
## Summary

- Allow Azure Identity token caching to fall back to unencrypted storage when platform keyring encryption is unavailable.

Closes #7