### PR TITLE
fix: save downloaded attachments as decoded files

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ uv run outlook-mcp serve    # Start MCP server (default, used by OpenClaw/Claude
 | Tool | Description |
 |------|-------------|
 | `outlook_list_attachments` | List attachments on a message. |
-| `outlook_download_attachment` | Download attachment (base64 or save to file). |
+| `outlook_download_attachment` | Download attachment and save decoded bytes to a file. |
 | `outlook_send_with_attachments` | Send message with file attachments (auto upload session for >3MB). |
 | `outlook_attach_to_draft` | Add attachments to an existing draft (auto upload session for >3MB). |
 | `outlook_remove_draft_attachment` | Remove a single attachment from a draft. |

--- a/SKILL.md
+++ b/SKILL.md
@@ -109,7 +109,7 @@ Provides AI agents with full access to mail, calendar, contacts, and tasks via M
 
 ### Attachments
 - `outlook_list_attachments` — List on a message
-- `outlook_download_attachment` — Download (base64 or save to file)
+- `outlook_download_attachment` — Download and save decoded bytes to a file
 - `outlook_send_with_attachments` — Send with files (auto upload session for >3MB)
 - `outlook_attach_to_draft` — Add attachments to an existing draft (auto upload session for >3MB)
 - `outlook_remove_draft_attachment` — Remove a single attachment from a draft

--- a/src/outlook_mcp/server.py
+++ b/src/outlook_mcp/server.py
@@ -733,9 +733,9 @@ async def outlook_download_attachment(
     ctx: Context,
     message_id: str,
     attachment_id: str,
-    save_path: str | None = None,
+    save_path: str,
 ) -> dict:
-    """Download an attachment. Returns base64 content or saves to file."""
+    """Download an attachment and save decoded bytes to a file."""
     client = _get_graph_client(ctx)
     return await mail_attachments.download_attachment(
         client.sdk_client,

--- a/src/outlook_mcp/tools/mail_attachments.py
+++ b/src/outlook_mcp/tools/mail_attachments.py
@@ -74,38 +74,28 @@ async def download_attachment(
     graph_client: Any,
     message_id: str,
     attachment_id: str,
-    save_path: str | None = None,
+    save_path: str,
 ) -> dict:
     """Download an attachment.
 
     GET /me/messages/{id}/attachments/{att_id}
-    If save_path is None, returns base64 content in the response dict.
-    If save_path is provided, writes bytes to file and returns the path.
+    Decodes content, writes bytes to save_path, and returns the path.
     """
     message_id = validate_graph_id(message_id)
     attachment_id = validate_graph_id(attachment_id)
-
-    if save_path is not None:
-        _validate_save_path(save_path)
+    _validate_save_path(save_path)
 
     attachment = (
         await graph_client.me.messages.by_message_id(message_id)
         .attachments.by_attachment_id(attachment_id)
         .get()
     )
+    content = base64.b64decode(attachment.content_bytes.decode("utf-8"), validate=True)
 
-    if save_path is not None:
-        with open(save_path, "wb") as f:
-            f.write(attachment.content_bytes)
-        return {
-            "saved_to": save_path,
-            "name": attachment.name,
-            "size": attachment.size,
-            "content_type": attachment.content_type,
-        }
-
+    with open(save_path, "wb") as f:
+        f.write(content)
     return {
-        "content_base64": base64.b64encode(attachment.content_bytes).decode("utf-8"),
+        "saved_to": save_path,
         "name": attachment.name,
         "size": attachment.size,
         "content_type": attachment.content_type,

--- a/tests/test_mail_attachments.py
+++ b/tests/test_mail_attachments.py
@@ -85,37 +85,15 @@ class TestListAttachments:
 
 
 class TestDownloadAttachment:
-    async def test_download_returns_base64(self):
-        """download_attachment returns base64 content when no save_path."""
+    async def test_download_writes_decoded_content_to_path(self, tmp_path):
+        """download_attachment decodes Graph contentBytes to file."""
+        raw_content = b"%PDF-1.7\nfile content bytes"
         mock_att = MagicMock()
         mock_att.id = "att1"
         mock_att.name = "report.pdf"
-        mock_att.size = 1024
+        mock_att.size = len(raw_content)
         mock_att.content_type = "application/pdf"
-        mock_att.content_bytes = b"file content bytes"
-
-        mock_client = MagicMock()
-        mock_client.me.messages.by_message_id.return_value.attachments.by_attachment_id.return_value.get = AsyncMock(  # noqa: E501
-            return_value=mock_att
-        )
-
-        result = await download_attachment(
-            mock_client, message_id="AAMkAG123=", attachment_id="att1"
-        )
-        expected_b64 = base64.b64encode(b"file content bytes").decode("utf-8")
-        assert result["content_base64"] == expected_b64
-        assert result["name"] == "report.pdf"
-        assert result["content_type"] == "application/pdf"
-        assert result["size"] == 1024
-
-    async def test_download_writes_to_path(self, tmp_path):
-        """download_attachment writes bytes to file when save_path given."""
-        mock_att = MagicMock()
-        mock_att.id = "att1"
-        mock_att.name = "report.pdf"
-        mock_att.size = 18
-        mock_att.content_type = "application/pdf"
-        mock_att.content_bytes = b"file content bytes"
+        mock_att.content_bytes = base64.b64encode(raw_content)
 
         mock_client = MagicMock()
         mock_client.me.messages.by_message_id.return_value.attachments.by_attachment_id.return_value.get = AsyncMock(  # noqa: E501
@@ -132,19 +110,29 @@ class TestDownloadAttachment:
         assert result["saved_to"] == save_path
         assert os.path.isfile(save_path)
         with open(save_path, "rb") as f:
-            assert f.read() == b"file content bytes"
+            assert f.read() == raw_content
 
     async def test_download_validates_message_id(self):
         """download_attachment rejects invalid message ID."""
         mock_client = MagicMock()
         with pytest.raises(ValueError):
-            await download_attachment(mock_client, message_id="", attachment_id="att1")
+            await download_attachment(
+                mock_client,
+                message_id="",
+                attachment_id="att1",
+                save_path="/tmp/report.pdf",
+            )
 
     async def test_download_validates_attachment_id(self):
         """download_attachment rejects invalid attachment ID."""
         mock_client = MagicMock()
         with pytest.raises(ValueError):
-            await download_attachment(mock_client, message_id="AAMkAG123=", attachment_id="")
+            await download_attachment(
+                mock_client,
+                message_id="AAMkAG123=",
+                attachment_id="",
+                save_path="/tmp/report.pdf",
+            )
 
     async def test_download_rejects_path_traversal(self):
         """download_attachment rejects save_path with .. traversal."""


### PR DESCRIPTION
## Summary

- Problem: Graph attachment `contentBytes` is base64-encoded, but the download tool could write that encoded content directly to disk.
- Solution: Make attachment downloads save-only, require `save_path`, decode `contentBytes` before writing the file, and update the MCP description, docs, and tests.