### PR TITLE
feat(mail): scheduled send + HTML body update + deferred-send read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to outlook-graph-mcp are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `outlook_create_draft` and `outlook_update_draft` accept a
+  `deferred_send_datetime: str` parameter (ISO 8601). The value is set as
+  the legacy MAPI `PR_DEFERRED_SEND_TIME` extended property (`SystemTime
+  0x3FEF`); once the draft is sent (e.g. via `outlook_send_draft`),
+  Exchange holds the message server-side until the given UTC instant.
+  This is the same mechanism Outlook desktop uses for "Delay Delivery"
+  and runs server-side, so the client doesn't need to be online at the
+  scheduled time. On `update_draft`, passing an empty string clears the
+  property. Inputs are validated and normalized to UTC ISO 8601 (`Z`
+  form).
+
 ## [1.5.2] — 2026-04-29
 
 ### Documentation / positioning

--- a/src/outlook_mcp/server.py
+++ b/src/outlook_mcp/server.py
@@ -126,10 +126,19 @@ async def outlook_read_message(
     ctx: Context,
     message_id: str,
     format: str = "text",
+    include_deferred_send: bool = False,
 ) -> dict:
-    """Get full message by ID. Format: text, html, or full (both)."""
+    """Get full message by ID. Format: text, html, or full (both).
+
+    Pass ``include_deferred_send=True`` to surface the
+    PR_DEFERRED_SEND_TIME extended property as ``deferred_send_datetime``
+    in the response. Useful when you need to recreate a scheduled draft
+    (e.g. delete + create-fresh) and want to preserve its scheduled time.
+    """
     client = _get_graph_client(ctx)
-    return await mail_read.read_message(client.sdk_client, message_id, format)
+    return await mail_read.read_message(
+        client.sdk_client, message_id, format, include_deferred_send
+    )
 
 
 @mcp.tool()
@@ -692,12 +701,18 @@ async def outlook_update_draft(
     to: list[str] | None = None,
     cc: list[str] | None = None,
     reply_to: list[str] | None = None,
+    is_html: bool = False,
     deferred_send_datetime: str | None = None,
 ) -> dict:
     """Update an existing draft message.
 
     Pass ``reply_to=[...]`` to overwrite the draft's Reply-To addresses;
     pass ``reply_to=[]`` to clear them.
+
+    Pass ``is_html=True`` when ``body`` is HTML. Required when overwriting a
+    draft that was originally composed as HTML in the Outlook web/desktop UI
+    — PATCHing such a draft with a Text body is rejected by the
+    consumer-Outlook MAPI store with ErrorAccessDenied / MapiSetProperties.
 
     Pass ``deferred_send_datetime`` (ISO 8601) to set or replace the
     draft's PR_DEFERRED_SEND_TIME extended property — the value Exchange
@@ -714,6 +729,7 @@ async def outlook_update_draft(
         to,
         cc,
         reply_to=reply_to,
+        is_html=is_html,
         deferred_send_datetime=deferred_send_datetime,
         config=config,
     )

--- a/src/outlook_mcp/server.py
+++ b/src/outlook_mcp/server.py
@@ -652,10 +652,19 @@ async def outlook_create_draft(
     is_html: bool = False,
     importance: str = "normal",
     reply_to: list[str] | None = None,
+    deferred_send_datetime: str | None = None,
 ) -> dict:
     """Create a draft message in the Drafts folder.
 
     Pass ``reply_to`` to pre-populate the draft's Reply-To addresses.
+
+    Pass ``deferred_send_datetime`` (ISO 8601, e.g.
+    ``"2026-05-06T08:00:00Z"``) to schedule the draft for delayed
+    delivery via the PR_DEFERRED_SEND_TIME extended property. Once the
+    draft is sent (e.g. with ``outlook_send_draft``), Exchange holds the
+    message server-side until that instant — the client doesn't need to
+    be online at the scheduled time. Match Outlook desktop's "Delay
+    Delivery" feature.
     """
     client = _get_graph_client(ctx)
     config = _get_config(ctx)
@@ -669,6 +678,7 @@ async def outlook_create_draft(
         is_html,
         importance,
         reply_to=reply_to,
+        deferred_send_datetime=deferred_send_datetime,
         config=config,
     )
 
@@ -682,11 +692,17 @@ async def outlook_update_draft(
     to: list[str] | None = None,
     cc: list[str] | None = None,
     reply_to: list[str] | None = None,
+    deferred_send_datetime: str | None = None,
 ) -> dict:
     """Update an existing draft message.
 
     Pass ``reply_to=[...]`` to overwrite the draft's Reply-To addresses;
     pass ``reply_to=[]`` to clear them.
+
+    Pass ``deferred_send_datetime`` (ISO 8601) to set or replace the
+    draft's PR_DEFERRED_SEND_TIME extended property — the value Exchange
+    reads to schedule delayed delivery once the draft is sent. Pass an
+    empty string to clear a previously-set deferred send time.
     """
     client = _get_graph_client(ctx)
     config = _get_config(ctx)
@@ -698,6 +714,7 @@ async def outlook_update_draft(
         to,
         cc,
         reply_to=reply_to,
+        deferred_send_datetime=deferred_send_datetime,
         config=config,
     )
 

--- a/src/outlook_mcp/tools/mail_drafts.py
+++ b/src/outlook_mcp/tools/mail_drafts.py
@@ -169,6 +169,7 @@ async def update_draft(
     to: list[str] | None = None,
     cc: list[str] | None = None,
     reply_to: list[str] | None = None,
+    is_html: bool = False,
     deferred_send_datetime: str | None = None,
     *,
     config: Config,
@@ -177,6 +178,11 @@ async def update_draft(
 
     Sends a PATCH with only the provided fields.
     Validates draft_id and any email addresses.
+
+    Pass ``is_html=True`` when ``body`` is HTML. Required when overwriting a
+    draft that was originally created as HTML (e.g. composed in the Outlook
+    web/desktop UI) — PATCHing such a draft with a Text body is rejected by
+    the consumer-Outlook MAPI store with ErrorAccessDenied / MapiSetProperties.
 
     Pass ``deferred_send_datetime`` (ISO 8601) to set or replace the
     PR_DEFERRED_SEND_TIME extended property on the draft, scheduling it
@@ -199,7 +205,7 @@ async def update_draft(
 
         msg.body = ItemBody()
         msg.body.content = body
-        msg.body.content_type = BodyType.Text
+        msg.body.content_type = BodyType.Html if is_html else BodyType.Text
 
     if to is not None:
         from msgraph.generated.models.email_address import EmailAddress

--- a/src/outlook_mcp/tools/mail_drafts.py
+++ b/src/outlook_mcp/tools/mail_drafts.py
@@ -8,7 +8,33 @@ from outlook_mcp.config import Config
 from outlook_mcp.pagination import apply_pagination, build_request_config, wrap_nextlink
 from outlook_mcp.permissions import CATEGORY_MAIL_DRAFTS, CATEGORY_MAIL_SEND, check_permission
 from outlook_mcp.tools.mail_read import _format_message_summary
-from outlook_mcp.validation import validate_email, validate_graph_id
+from outlook_mcp.validation import validate_datetime, validate_email, validate_graph_id
+
+# MAPI tag PR_DEFERRED_SEND_TIME (0x3FEF, PtypTime) — the legacy extended
+# property the Outlook transport reads to schedule deferred sending. Setting
+# this on a draft and then sending it instructs Exchange to hold the message
+# in the Outbox until the given UTC instant. This is the same mechanism the
+# Outlook desktop client uses for "Delay Delivery", and it runs server-side
+# so the client doesn't need to be online at the scheduled time.
+_PR_DEFERRED_SEND_TIME_ID = "SystemTime 0x3FEF"
+
+
+def _build_deferred_send_property(deferred_send_datetime: str):
+    """Return a SingleValueLegacyExtendedProperty for PR_DEFERRED_SEND_TIME.
+
+    `deferred_send_datetime` must be ISO 8601. validate_datetime normalizes
+    to UTC and rejects malformed input. Caller is responsible for passing
+    a future timestamp — the server rejects past values with a 400.
+    """
+    from msgraph.generated.models.single_value_legacy_extended_property import (
+        SingleValueLegacyExtendedProperty,
+    )
+
+    normalized = validate_datetime(deferred_send_datetime)
+    prop = SingleValueLegacyExtendedProperty()
+    prop.id = _PR_DEFERRED_SEND_TIME_ID
+    prop.value = normalized
+    return prop, normalized
 
 
 async def list_drafts(
@@ -61,6 +87,7 @@ async def create_draft(
     is_html: bool = False,
     importance: str = "normal",
     reply_to: list[str] | None = None,
+    deferred_send_datetime: str | None = None,
     *,
     config: Config,
 ) -> dict:
@@ -68,6 +95,13 @@ async def create_draft(
 
     Validates all email addresses, builds a Message object,
     and POSTs to /me/messages (which creates in Drafts).
+
+    Pass ``deferred_send_datetime`` (ISO 8601, UTC preferred) to schedule the
+    draft for delayed delivery. The value is set as the
+    PR_DEFERRED_SEND_TIME extended property; once the draft is sent
+    (e.g. via outlook_send_draft), Exchange holds the message server-side
+    until the given instant. This is the standard "Delay Delivery"
+    mechanism used by Outlook desktop and survives client offline state.
     """
     check_permission(config, CATEGORY_MAIL_DRAFTS, "outlook_create_draft")
 
@@ -110,13 +144,21 @@ async def create_draft(
     }
     msg.importance = importance_map.get(importance, Importance.Normal)
 
+    deferred_normalized = None
+    if deferred_send_datetime is not None:
+        prop, deferred_normalized = _build_deferred_send_property(deferred_send_datetime)
+        msg.single_value_extended_properties = [prop]
+
     # POST /me/messages creates a draft
     created = await graph_client.me.messages.post(msg)
 
-    return {
+    result = {
         "status": "created",
         "draft_id": created.id,
     }
+    if deferred_normalized is not None:
+        result["deferred_send_datetime"] = deferred_normalized
+    return result
 
 
 async def update_draft(
@@ -127,6 +169,7 @@ async def update_draft(
     to: list[str] | None = None,
     cc: list[str] | None = None,
     reply_to: list[str] | None = None,
+    deferred_send_datetime: str | None = None,
     *,
     config: Config,
 ) -> dict:
@@ -134,6 +177,11 @@ async def update_draft(
 
     Sends a PATCH with only the provided fields.
     Validates draft_id and any email addresses.
+
+    Pass ``deferred_send_datetime`` (ISO 8601) to set or replace the
+    PR_DEFERRED_SEND_TIME extended property on the draft, scheduling it
+    for delayed delivery once it's sent. Pass an empty string to clear a
+    previously-set deferred send time.
     """
     check_permission(config, CATEGORY_MAIL_DRAFTS, "outlook_update_draft")
     draft_id = validate_graph_id(draft_id)
@@ -195,12 +243,33 @@ async def update_draft(
 
         msg.reply_to = [_make_reply_to_recipient(e) for e in validated_reply_to]
 
+    deferred_normalized = None
+    if deferred_send_datetime is not None:
+        if deferred_send_datetime == "":
+            # Clearing the deferred-send property requires PATCHing an
+            # empty value via the same extended-property channel — Graph
+            # interprets a null/empty value as "remove this property".
+            from msgraph.generated.models.single_value_legacy_extended_property import (
+                SingleValueLegacyExtendedProperty,
+            )
+            prop = SingleValueLegacyExtendedProperty()
+            prop.id = _PR_DEFERRED_SEND_TIME_ID
+            prop.value = ""
+            msg.single_value_extended_properties = [prop]
+            deferred_normalized = ""
+        else:
+            prop, deferred_normalized = _build_deferred_send_property(deferred_send_datetime)
+            msg.single_value_extended_properties = [prop]
+
     await graph_client.me.messages.by_message_id(draft_id).patch(msg)
 
-    return {
+    result = {
         "status": "updated",
         "draft_id": draft_id,
     }
+    if deferred_normalized is not None:
+        result["deferred_send_datetime"] = deferred_normalized
+    return result
 
 
 async def send_draft(

--- a/src/outlook_mcp/tools/mail_read.py
+++ b/src/outlook_mcp/tools/mail_read.py
@@ -154,11 +154,74 @@ async def read_message(
     graph_client: Any,
     message_id: str,
     format: str = "text",
+    include_deferred_send: bool = False,
 ) -> dict:
-    """Read a single message by ID."""
+    """Read a single message by ID.
+
+    Pass ``include_deferred_send=True`` to surface the
+    PR_DEFERRED_SEND_TIME extended property (the value Exchange reads to
+    schedule deferred delivery) as ``deferred_send_datetime`` in the
+    response. ``null`` if the property isn't set on the message.
+    """
     message_id = validate_graph_id(message_id)
 
-    msg = await graph_client.me.messages.by_message_id(message_id).get()
+    deferred_value: str | None = None
+
+    if include_deferred_send:
+        # PR_DEFERRED_SEND_TIME extended property fetch.
+        #
+        # Kiota's typed query-parameter encoder drops the inner
+        # `$filter` from `$expand=singleValueExtendedProperties($filter=...)`
+        # during URL building, so we build a raw URL via the
+        # RAW_URL_KEY path-parameter slot and let the adapter execute it
+        # through the normal auth + retry pipeline.
+        from urllib.parse import quote
+        from kiota_abstractions.method import Method
+        from kiota_abstractions.request_information import RequestInformation
+        from msgraph.generated.models.message import Message
+        from msgraph.generated.models.o_data_errors.o_data_error import ODataError
+
+        from outlook_mcp.tools.mail_drafts import _PR_DEFERRED_SEND_TIME_ID
+
+        adapter = graph_client.me.messages.by_message_id(
+            message_id
+        ).request_adapter
+        filter_expr = f"id eq '{_PR_DEFERRED_SEND_TIME_ID}'"
+        # Keep `=`, space, and single quotes literal — Graph requires
+        # them in the $filter clause and they're safe inside a query
+        # parameter value. Hex/special chars in the property tag still
+        # get percent-encoded.
+        encoded_filter = quote(filter_expr, safe="= '")
+        raw_url = (
+            f"{adapter.base_url}/me/messages/{quote(message_id, safe='')}"
+            f"?$expand=singleValueExtendedProperties("
+            f"$filter={encoded_filter})"
+        )
+
+        info = RequestInformation()
+        info.http_method = Method.GET
+        info.path_parameters = {RequestInformation.RAW_URL_KEY: raw_url}
+        info.url_template = "{+baseurl}"
+        info.headers.try_add("Accept", "application/json")
+        msg = await adapter.send_async(
+            info,
+            Message,
+            {
+                "4XX": ODataError,
+                "5XX": ODataError,
+            },
+        )
+
+        # Graph normalizes the property tag's hex segment to lowercase
+        # in the response (`SystemTime 0x3fef`), even when we POST/PATCH
+        # it as uppercase. Case-insensitive match.
+        target = _PR_DEFERRED_SEND_TIME_ID.lower()
+        for prop in msg.single_value_extended_properties or []:
+            if (prop.id or "").lower() == target:
+                deferred_value = prop.value
+                break
+    else:
+        msg = await graph_client.me.messages.by_message_id(message_id).get()
 
     from_addr = ""
     from_name = ""
@@ -207,7 +270,7 @@ async def read_message(
     if msg.flag and msg.flag.flag_status and hasattr(msg.flag.flag_status, "value"):
         flag_status = msg.flag.flag_status.value
 
-    return {
+    result = {
         "id": msg.id,
         "subject": sanitize_output(msg.subject or "(no subject)"),
         "from_email": from_addr,
@@ -225,6 +288,11 @@ async def read_message(
         "flag": flag_status,
         "conversation_id": msg.conversation_id or "",
     }
+
+    if include_deferred_send:
+        result["deferred_send_datetime"] = deferred_value
+
+    return result
 
 
 async def search_mail(

--- a/src/outlook_mcp/tools/mail_read.py
+++ b/src/outlook_mcp/tools/mail_read.py
@@ -176,6 +176,7 @@ async def read_message(
         # RAW_URL_KEY path-parameter slot and let the adapter execute it
         # through the normal auth + retry pipeline.
         from urllib.parse import quote
+
         from kiota_abstractions.method import Method
         from kiota_abstractions.request_information import RequestInformation
         from msgraph.generated.models.message import Message

--- a/tests/test_mail_drafts.py
+++ b/tests/test_mail_drafts.py
@@ -278,6 +278,51 @@ class TestUpdateDraft:
         assert result["draft_id"] == "AAMkAG123="
         msg_builder.patch.assert_called_once()
 
+    async def test_update_draft_body_defaults_to_text(self):
+        """update_draft sends body as Text by default."""
+        msg_builder = MagicMock()
+        msg_builder.patch = AsyncMock()
+
+        client = MagicMock()
+        client.me.messages.by_message_id = MagicMock(return_value=msg_builder)
+
+        await update_draft(
+            client,
+            draft_id="AAMkAG123=",
+            body="plain text",
+            config=_CFG,
+        )
+
+        sent_msg = msg_builder.patch.call_args[0][0]
+        from msgraph.generated.models.body_type import BodyType
+
+        assert sent_msg.body.content == "plain text"
+        assert sent_msg.body.content_type == BodyType.Text
+
+    async def test_update_draft_body_html_when_is_html(self):
+        """update_draft sends body as Html when is_html=True (required for
+        drafts originally composed as HTML in the Outlook UI — Text PATCH on
+        an HTML draft triggers MapiSetProperties / ErrorAccessDenied)."""
+        msg_builder = MagicMock()
+        msg_builder.patch = AsyncMock()
+
+        client = MagicMock()
+        client.me.messages.by_message_id = MagicMock(return_value=msg_builder)
+
+        await update_draft(
+            client,
+            draft_id="AAMkAG123=",
+            body="<p>hello</p>",
+            is_html=True,
+            config=_CFG,
+        )
+
+        sent_msg = msg_builder.patch.call_args[0][0]
+        from msgraph.generated.models.body_type import BodyType
+
+        assert sent_msg.body.content == "<p>hello</p>"
+        assert sent_msg.body.content_type == BodyType.Html
+
     async def test_update_draft_validates_graph_id(self):
         """update_draft rejects invalid draft IDs."""
         client = MagicMock()

--- a/tests/test_mail_drafts.py
+++ b/tests/test_mail_drafts.py
@@ -197,6 +197,66 @@ class TestCreateDraft:
                 config=_CFG,
             )
 
+    async def test_create_draft_sets_deferred_send_property(self):
+        """create_draft attaches PR_DEFERRED_SEND_TIME extended property."""
+        created_msg = MagicMock()
+        created_msg.id = "AAMkDeferred="
+
+        client = MagicMock()
+        client.me.messages.post = AsyncMock(return_value=created_msg)
+
+        result = await create_draft(
+            client,
+            to=["to@test.com"],
+            subject="Scheduled",
+            body="Hello",
+            deferred_send_datetime="2026-05-06T08:00:00Z",
+            config=_CFG,
+        )
+
+        posted_msg = client.me.messages.post.call_args.args[0]
+        assert posted_msg.single_value_extended_properties is not None
+        assert len(posted_msg.single_value_extended_properties) == 1
+        prop = posted_msg.single_value_extended_properties[0]
+        assert prop.id == "SystemTime 0x3FEF"
+        assert prop.value == "2026-05-06T08:00:00Z"
+        assert result["deferred_send_datetime"] == "2026-05-06T08:00:00Z"
+
+    async def test_create_draft_normalizes_timezone_offset(self):
+        """create_draft normalizes a TZ-offset datetime to UTC Z form."""
+        created_msg = MagicMock()
+        created_msg.id = "AAMkDeferredTZ="
+
+        client = MagicMock()
+        client.me.messages.post = AsyncMock(return_value=created_msg)
+
+        # 10:00 in Helsinki (DST, +03:00) -> 07:00 UTC
+        result = await create_draft(
+            client,
+            to=["to@test.com"],
+            subject="Scheduled",
+            body="Hello",
+            deferred_send_datetime="2026-05-06T10:00:00+03:00",
+            config=_CFG,
+        )
+
+        assert result["deferred_send_datetime"] == "2026-05-06T07:00:00Z"
+        prop = client.me.messages.post.call_args.args[0].single_value_extended_properties[0]
+        assert prop.value == "2026-05-06T07:00:00Z"
+
+    async def test_create_draft_rejects_malformed_deferred_send(self):
+        """create_draft rejects non-ISO deferred_send_datetime values."""
+        client = MagicMock()
+        with pytest.raises(ValueError):
+            await create_draft(
+                client,
+                to=["to@test.com"],
+                subject="Test",
+                body="Hello",
+                deferred_send_datetime="tomorrow at 8",
+                config=_CFG,
+            )
+
 
 class TestUpdateDraft:
     async def test_update_draft_patches_partial(self):
@@ -288,6 +348,61 @@ class TestUpdateDraft:
                 client,
                 draft_id="AAMkAG123=",
                 reply_to=["bogus"],
+                config=_CFG,
+            )
+
+    async def test_update_draft_sets_deferred_send_property(self):
+        """update_draft attaches PR_DEFERRED_SEND_TIME on the PATCH payload."""
+        msg_builder = MagicMock()
+        msg_builder.patch = AsyncMock()
+
+        client = MagicMock()
+        client.me.messages.by_message_id = MagicMock(return_value=msg_builder)
+
+        result = await update_draft(
+            client,
+            draft_id="AAMkAG123=",
+            deferred_send_datetime="2026-05-06T08:00:00Z",
+            config=_CFG,
+        )
+
+        patched_msg = msg_builder.patch.call_args.args[0]
+        props = patched_msg.single_value_extended_properties
+        assert props is not None and len(props) == 1
+        assert props[0].id == "SystemTime 0x3FEF"
+        assert props[0].value == "2026-05-06T08:00:00Z"
+        assert result["deferred_send_datetime"] == "2026-05-06T08:00:00Z"
+
+    async def test_update_draft_clears_deferred_send_with_empty_string(self):
+        """update_draft with deferred_send_datetime='' clears the property."""
+        msg_builder = MagicMock()
+        msg_builder.patch = AsyncMock()
+
+        client = MagicMock()
+        client.me.messages.by_message_id = MagicMock(return_value=msg_builder)
+
+        result = await update_draft(
+            client,
+            draft_id="AAMkAG123=",
+            deferred_send_datetime="",
+            config=_CFG,
+        )
+
+        patched_msg = msg_builder.patch.call_args.args[0]
+        props = patched_msg.single_value_extended_properties
+        assert props is not None and len(props) == 1
+        assert props[0].id == "SystemTime 0x3FEF"
+        assert props[0].value == ""
+        assert result["deferred_send_datetime"] == ""
+
+    async def test_update_draft_rejects_malformed_deferred_send(self):
+        """update_draft rejects non-ISO deferred_send_datetime values."""
+        client = MagicMock()
+        with pytest.raises(ValueError):
+            await update_draft(
+                client,
+                draft_id="AAMkAG123=",
+                deferred_send_datetime="not-a-date",
                 config=_CFG,
             )
 


### PR DESCRIPTION
## Summary

Adds a `deferred_send_datetime: str` parameter to `outlook_create_draft` and `outlook_update_draft` so callers can schedule a draft for delayed delivery without leaving the MCP. The value is attached to the message as a `SingleValueLegacyExtendedProperty` with id `SystemTime 0x3FEF` — the legacy MAPI tag `PR_DEFERRED_SEND_TIME`, which is the same mechanism Outlook desktop's **Delay Delivery** feature uses.

Once the draft is sent (e.g. via `outlook_send_draft`), Exchange holds the message server-side until the configured UTC instant. The client does not need to be online at the scheduled time — delivery is handled by the transport.

## Why

Today the MCP cannot create a *scheduled* draft. Agents using the MCP for offer pipelines or any time-shifted send have to bypass the server and call Microsoft Graph directly to set the extended property, which defeats the purpose of going through the MCP. This PR closes that gap.

## Implementation

- `tools/mail_drafts.py` gains a small `_build_deferred_send_property` helper that runs the input through the existing `validate_datetime` (rejects non-ISO inputs, normalizes timezone offsets to UTC `Z` form) and returns a typed SDK property model plus the normalized timestamp.
- `create_draft` attaches `[prop]` to `msg.single_value_extended_properties` before posting and returns the normalized timestamp in the result dict.
- `update_draft` accepts the same parameter. Passing an empty string clears the property by sending `value=""`, which Graph treats as remove.
- Both MCP wrappers in `server.py` expose the new param with docstrings explaining the Delay-Delivery semantics.
- `CHANGELOG.md` entry under `[Unreleased]`.

## Tests

Six new pytest cases in `tests/test_mail_drafts.py`:

- `create_draft` attaches the extended property with the right id + value.
- TZ-offset input (`...+03:00`) is normalized to UTC `Z` in both the SDK property and the result dict.
- `create_draft` rejects malformed input with `ValueError`.
- `update_draft` attaches the extended property on the PATCH payload.
- `update_draft` with empty string clears the property (`value=""`).
- `update_draft` rejects malformed input.

Full suite: **411 passed, 6 skipped**.

## Compatibility

- New parameter defaults to `None`, so existing callers are unaffected.
- No new dependencies; the `SingleValueLegacyExtendedProperty` model is already pulled in transitively by `msgraph-sdk`.
- Read-only mode and the existing permission check (`CATEGORY_MAIL_DRAFTS`) cover the new param automatically.

---

## Update — round-tripping existing drafts

Two follow-up fixes pushed on top of the original commit, both surfaced when scripting a delete + re-create flow against existing scheduled drafts on a consumer Outlook account:

- **`update_draft` now accepts `is_html=True`.** Required when overwriting drafts originally composed as HTML in the Outlook web/desktop UI — PATCHing such a draft with a Text body is rejected by the consumer-Outlook MAPI store with `ErrorAccessDenied` / `MapiSetProperties`. Default stays Text for back-compat. Two new pytest cases cover both branches.
- **`read_message` now accepts `include_deferred_send=True`.** Surfaces the `PR_DEFERRED_SEND_TIME` extended property as `deferred_send_datetime` in the response. Two implementation notes:
  - Kiota's typed query-parameter encoder drops the inner `$filter` from `$expand=singleValueExtendedProperties($filter=...)` during URL building, so the implementation builds a raw URL and routes it through the adapter via `RequestInformation.RAW_URL_KEY` — same auth + retry pipeline as the typed call.
  - Graph normalizes the property tag's hex segment to lowercase in the response (`SystemTime 0x3fef`) even when we POST/PATCH it as uppercase, so the lookup is case-insensitive.

Together these enable a callable workflow of *list → read with schedule → delete → re-create with same schedule* on consumer Outlook, where in-place body PATCH against existing drafts is otherwise blocked by the MAPI store.