### PR TITLE
fix(auth): warn once when token cache falls back to plaintext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `content_base64`, switch to passing `save_path` and reading the file.
   ([#9])
 
+### Changed
+- The unencrypted token-cache fallback enabled in #8 now emits a
+  one-time `logger.warning(...)` on the first credential build when
+  PyGObject/libsecret isn't importable. macOS Keychain and Windows
+  DPAPI still cache encrypted as before; only Linux installs without
+  PyGObject (e.g. `uv tool install` on Ubuntu — issue #7) take the
+  plaintext path, and now surface that fact to operators instead of
+  silently writing tokens to disk.
+
 [#9]: https://github.com/mpalermiti/outlook-mcp/pull/9
 [#10]: https://github.com/mpalermiti/outlook-mcp/pull/10
 

--- a/src/outlook_mcp/auth.py
+++ b/src/outlook_mcp/auth.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import importlib.util
 import logging
+import sys
 from pathlib import Path
 
 from azure.identity import (
@@ -15,6 +17,11 @@ from outlook_mcp.config import DEFAULT_CONFIG_DIR, Config
 from outlook_mcp.errors import AuthRequiredError
 
 logger = logging.getLogger(__name__)
+
+# Process-local latch so the unencrypted-fallback warning fires at most
+# once per run — _make_credential is called from both login_interactive
+# and try_cached_token, often multiple times during startup.
+_warned_unencrypted_fallback = False
 
 SCOPES_READWRITE = [
     "Mail.ReadWrite",
@@ -35,6 +42,21 @@ SCOPES_READONLY = [
 
 CACHE_NAME = "outlook-mcp"
 AUTH_RECORD_FILE = "auth_record.json"
+
+
+def _unencrypted_fallback_will_be_used() -> bool:
+    """Return True if msal_extensions will fall back to plaintext caching.
+
+    Mirrors msal_extensions' libsecret-availability check: macOS uses
+    Keychain and Windows uses DPAPI, both always encrypted, so only
+    Linux is at risk — and only when PyGObject/libsecret isn't
+    importable in the current Python environment (the failure mode
+    reported in #7 for `uv tool install`).
+    """
+    if sys.platform != "linux":
+        return False
+    return importlib.util.find_spec("gi") is None
+
 
 # The Graph SDK always requests .default scope internally, so we must
 # acquire and cache tokens with the same scope to avoid cache misses
@@ -93,10 +115,24 @@ class AuthManager:
         auth_record: AuthenticationRecord | None = None,
     ) -> DeviceCodeCredential:
         """Create a DeviceCodeCredential with persistent cache."""
+        global _warned_unencrypted_fallback
         cache_options = TokenCachePersistenceOptions(
             name=CACHE_NAME,
             allow_unencrypted_storage=True,
         )
+        if not _warned_unencrypted_fallback and _unencrypted_fallback_will_be_used():
+            logger.warning(
+                "Token cache will be stored unencrypted on disk because "
+                "PyGObject/libsecret is not importable in this Python "
+                "environment (common with `uv tool install` on Linux — "
+                "the tool's isolated venv can't see system PyGObject). "
+                "To enable encrypted caching via libsecret/gnome-keyring, "
+                "install the system packages "
+                "(apt: `gnome-keyring libsecret-1-0 python3-gi`) and "
+                "re-create the venv with `--system-site-packages`. See "
+                "https://github.com/mpalermiti/outlook-mcp/issues/7."
+            )
+            _warned_unencrypted_fallback = True
         kwargs = {
             "client_id": self.config.client_id,
             "tenant_id": self.config.tenant_id,
@@ -124,9 +160,7 @@ class AuthManager:
                 "client_id in ~/.outlook-mcp/config.json."
             )
 
-        def _on_device_code(
-            verification_uri: str, user_code: str, expires_on: object
-        ) -> None:
+        def _on_device_code(verification_uri: str, user_code: str, expires_on: object) -> None:
             print(f"Visit:  {verification_uri}")
             print(f"Code:   {user_code}")
             print()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,10 +1,22 @@
 """Tests for auth module."""
 
+import logging
+from unittest.mock import patch
+
 import pytest
 
-from outlook_mcp.auth import AuthManager
+from outlook_mcp import auth as auth_module
+from outlook_mcp.auth import AuthManager, _unencrypted_fallback_will_be_used
 from outlook_mcp.config import Config
 from outlook_mcp.errors import AuthRequiredError
+
+
+@pytest.fixture(autouse=True)
+def _reset_unencrypted_warning_latch():
+    """Reset the once-per-process warning latch between tests."""
+    auth_module._warned_unencrypted_fallback = False
+    yield
+    auth_module._warned_unencrypted_fallback = False
 
 
 def test_auth_manager_init():
@@ -67,3 +79,73 @@ def test_try_cached_token_returns_false_without_client_id():
     config = Config()
     auth = AuthManager(config)
     assert auth.try_cached_token(auth.get_scopes()) is False
+
+
+class TestUnencryptedFallbackDetection:
+    """_unencrypted_fallback_will_be_used mirrors msal_extensions' check."""
+
+    def test_macos_is_never_fallback(self):
+        """macOS uses Keychain — fallback is impossible."""
+        with patch.object(auth_module.sys, "platform", "darwin"):
+            assert _unencrypted_fallback_will_be_used() is False
+
+    def test_windows_is_never_fallback(self):
+        """Windows uses DPAPI — fallback is impossible."""
+        with patch.object(auth_module.sys, "platform", "win32"):
+            assert _unencrypted_fallback_will_be_used() is False
+
+    def test_linux_with_gi_available(self):
+        """Linux with PyGObject importable uses libsecret — no fallback."""
+        with (
+            patch.object(auth_module.sys, "platform", "linux"),
+            patch.object(auth_module.importlib.util, "find_spec", return_value=object()),
+        ):
+            assert _unencrypted_fallback_will_be_used() is False
+
+    def test_linux_without_gi_uses_fallback(self):
+        """Linux without PyGObject (issue #7) triggers the fallback path."""
+        with (
+            patch.object(auth_module.sys, "platform", "linux"),
+            patch.object(auth_module.importlib.util, "find_spec", return_value=None),
+        ):
+            assert _unencrypted_fallback_will_be_used() is True
+
+
+class TestUnencryptedFallbackWarning:
+    """_make_credential emits a warning at most once when fallback is in use."""
+
+    def test_warning_fires_once_when_fallback_active(self, caplog):
+        """A single warning is logged on the first credential build."""
+        config = Config(client_id="test-id")
+        auth = AuthManager(config)
+
+        with (
+            caplog.at_level(logging.WARNING, logger="outlook_mcp.auth"),
+            patch(
+                "outlook_mcp.auth._unencrypted_fallback_will_be_used",
+                return_value=True,
+            ),
+        ):
+            auth._make_credential()
+            auth._make_credential()
+
+        fallback_warnings = [r for r in caplog.records if "unencrypted" in r.getMessage().lower()]
+        assert len(fallback_warnings) == 1
+        assert fallback_warnings[0].levelno == logging.WARNING
+
+    def test_no_warning_when_fallback_inactive(self, caplog):
+        """No fallback warning is logged when encrypted storage is available."""
+        config = Config(client_id="test-id")
+        auth = AuthManager(config)
+
+        with (
+            caplog.at_level(logging.WARNING, logger="outlook_mcp.auth"),
+            patch(
+                "outlook_mcp.auth._unencrypted_fallback_will_be_used",
+                return_value=False,
+            ),
+        ):
+            auth._make_credential()
+
+        fallback_warnings = [r for r in caplog.records if "unencrypted" in r.getMessage().lower()]
+        assert fallback_warnings == []


### PR DESCRIPTION
## Summary
- Follow-up to #8. That PR enabled `allow_unencrypted_storage=True` to unblock `uv tool install` on Linux (issue #7), but the fallback fired silently — operators had no signal that tokens were now being written to disk in cleartext at `~/.IdentityService/`.
- Add a one-time `logger.warning(...)` on first credential build when the fallback will actually be used. Detection mirrors msal_extensions' own libsecret-availability check: returns `True` only on Linux when PyGObject (`gi`) isn't importable in the current Python environment — exactly the failure mode #7 reported. macOS Keychain and Windows DPAPI continue to cache encrypted as before and get no warning.
- A process-local latch (`_warned_unencrypted_fallback`) keeps the warning from firing twice when the MCP server calls `_make_credential` from both `login_interactive` and `try_cached_token` during startup.

## Why a warning, not a hard fail
This PR deliberately stays in "warn + continue" mode. The fallback exists for a real reason — without it, `uv tool install` users on Linux get no usable install at all (the original #7 bug). A warning gives operators the signal they need to choose: install `python3-gi` + `gnome-keyring` if encrypted caching matters, or accept the trade-off if they're running on a trusted single-user host.

## Tests
Six new pytest cases in `tests/test_auth.py`:
- macOS / Windows / Linux-with-gi → no fallback detected.
- Linux-without-gi → fallback detected.
- `_make_credential` emits exactly one warning across two calls when fallback is active.
- `_make_credential` emits no fallback warning when encrypted storage is available.

Full suite: **416 passed, 6 skipped**. Ruff clean.

## Test plan
- [ ] On macOS (this machine): manually run `outlook-mcp auth`, confirm no warning is logged.
- [ ] On a Linux box without PyGObject installed (or in a `uv tool install` env): confirm warning appears once at startup and the device-code flow still works.

Generated with [Claude Code](https://claude.com/claude-code)