### PR TITLE
Add pre-release Graph smoke test (scripts/preflight.py)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Works with any MCP client (OpenClaw, Claude Code, Cursor).
 - `uv run ruff check src/ tests/` — lint
 - `uv run ruff format src/ tests/` — format
 - `uv run outlook-mcp` — start server (stdio)
+- `uv run python scripts/preflight.py` — pre-release Graph smoke test (must pass before tagging; see `RELEASING.md`)
 
 ## Architecture
 - `src/outlook_mcp/server.py` — FastMCP entry point, lifespan context

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,84 @@
+# Releasing outlook-mcp
+
+Checklist for cutting a new release.
+
+## 1. Smoke-test against the live Graph API
+
+```bash
+uv run python scripts/preflight.py
+```
+
+Hits every Graph endpoint family the tools depend on with the locally-cached token. Flags any endpoint that returns 403 or 501 — the "not supported for this account type" signal that mocked unit tests can't catch.
+
+Read-only. No writes, no sends, no mailbox state changes.
+
+If the script reports failures, do not tag. Either fix the affected tools or remove them from the release. v1.7.0 shipped four tools backed by `/me/mailboxSettings/*` that Microsoft Graph does not support on personal accounts; v1.7.1 yanked them. This script would have caught it in 30 seconds.
+
+When adding a new tool that hits a Graph endpoint family not yet covered, add a row to `ENDPOINTS` in `scripts/preflight.py`.
+
+## 2. Tests + lint
+
+```bash
+uv run pytest --tb=no -q
+uv run ruff check src/ tests/
+```
+
+A single pre-existing failure (`test_graph.py::test_graph_client_init`, SOCKS env import) is expected and unrelated.
+
+## 3. Version bump
+
+Update in lockstep:
+
+- `pyproject.toml` — `version = "X.Y.Z"`
+- `server.json` — both `version` fields + `description` (tool count if it changed)
+- `CHANGELOG.md` — new `## [X.Y.Z] — YYYY-MM-DD` entry
+- `SKILL.md` — `## Tools (N)` heading + frontmatter `description` if count changed
+- `README.md` — counts and tables if they changed
+- `ROADMAP.md` — move shipped items from Near-term to Done
+- `CLAUDE.md` — tools listing if you added/removed a module
+
+## 4. PR + merge
+
+```bash
+gh pr create --title "vX.Y.Z: <summary>" --body "<changelog excerpt>"
+# wait for CI green
+gh pr merge <num> --rebase --delete-branch
+git checkout main && git pull --ff-only
+```
+
+## 5. Tag + GitHub release
+
+```bash
+gh release create vX.Y.Z --target main --title "vX.Y.Z" --notes "<changelog body>"
+```
+
+## 6. Publish
+
+```bash
+uv build
+uv publish dist/outlook_graph_mcp-X.Y.Z-py3-none-any.whl dist/outlook_graph_mcp-X.Y.Z.tar.gz
+
+clawhub publish "$(pwd)" --version X.Y.Z --tags latest --changelog "<one-liner>"
+
+mcp-publisher publish   # may need `mcp-publisher login github` if JWT expired
+```
+
+## 7. Update GitHub About
+
+If tool count or categories changed:
+
+```bash
+gh repo edit mpalermiti/outlook-mcp --description "MCP server for Microsoft Outlook personal accounts via Microsoft Graph API. N tools across K categories — mail, calendar, contacts, tasks, drafts, attachments. Community project, not affiliated with Microsoft."
+```
+
+## 8. Verify
+
+```bash
+curl -s https://pypi.org/pypi/outlook-graph-mcp/X.Y.Z/json | python3 -c "import json,sys; print(json.load(sys.stdin)['info']['version'])"
+```
+
+And confirm the MCP registry shows the new version as `(latest)`:
+
+```bash
+curl -s 'https://registry.modelcontextprotocol.io/v0/servers?search=mpalermiti&limit=20' | python3 -c "import json,sys; [print(s['server'].get('version'), '(latest)' if s.get('_meta',{}).get('io.modelcontextprotocol.registry/official',{}).get('isLatest') else '') for s in json.load(sys.stdin).get('servers', [])]"
+```

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -1,0 +1,117 @@
+"""Pre-release smoke test against the live Microsoft Graph API.
+
+Run before tagging a release. Hits every Graph endpoint family that
+outlook-mcp tools depend on, using the locally-cached token, and flags
+any endpoint that returns 403 or 501 — the "not supported for this
+account type" signals that unit tests can't catch.
+
+Read-only. No writes, no sends, no mailbox state changes.
+
+Why this exists: v1.7.0 shipped four mailbox-settings tools backed by
+/me/mailboxSettings/*, which Microsoft Graph does not support on
+personal Microsoft accounts (the project's only target). Unit tests
+passed because the SDK was mocked. A 30-second curl against the live
+endpoint would have caught it. This script is that 30-second curl,
+codified.
+
+Usage:
+    uv run python scripts/preflight.py
+
+Requires that `outlook-mcp auth` has been run successfully — the
+script reuses the cached token. Exits 0 on success, non-zero on any
+endpoint failure.
+"""
+
+from __future__ import annotations
+
+import sys
+from urllib.parse import urljoin
+
+import httpx
+
+from outlook_mcp.auth import AuthManager
+from outlook_mcp.config import load_config
+
+GRAPH_BASE = "https://graph.microsoft.com/v1.0/"
+
+# Each row covers one Graph endpoint family. The path is the smallest
+# request that exercises the surface — usually a $top=1 list — so the
+# script runs fast and doesn't drag the user's full mailbox over the
+# wire. The label maps to the outlook_mcp tool group(s) that depend
+# on this endpoint, so a failure points at the broken tools directly.
+ENDPOINTS: list[tuple[str, str]] = [
+    ("me", "Auth / whoami"),
+    ("me/messages?$top=1", "Mail read / search"),
+    ("me/mailFolders?$top=1", "Mail folders"),
+    ("me/mailFolders/drafts/messages?$top=1", "Drafts"),
+    ("me/events?$top=1", "Calendar read"),
+    ("me/calendars", "Calendar list"),
+    ("me/contacts?$top=1", "Contacts"),
+    ("me/todo/lists", "To Do"),
+    ("me/inferenceClassification/overrides", "Focused Inbox overrides"),
+    ("me/outlook/masterCategories", "Categories"),
+]
+
+
+def fetch_token() -> str:
+    config = load_config()
+    am = AuthManager(config)
+    am.try_cached_token(am.get_token_scopes())
+    cred = am.get_credential()
+    tok = cred.get_token("https://graph.microsoft.com/.default")
+    return tok.token
+
+
+def run() -> int:
+    try:
+        token = fetch_token()
+    except Exception as exc:
+        print(f"FAIL  could not acquire token — {exc}")
+        print("Run `outlook-mcp auth` first.")
+        return 2
+
+    headers = {"Authorization": f"Bearer {token}"}
+    failures: list[str] = []
+
+    for path, label in ENDPOINTS:
+        url = urljoin(GRAPH_BASE, path)
+        try:
+            r = httpx.get(url, headers=headers, timeout=20)
+        except Exception as exc:
+            print(f"FAIL  {label:30s} {path}  exception: {exc}")
+            failures.append(label)
+            continue
+
+        # 200/204: endpoint is supported and the request succeeded.
+        # 403/501: the failures we exist to catch — endpoint isn't
+        #   supported for this account type, or scopes are wrong.
+        # 4xx other: usually a query-shape issue (we're not testing
+        #   request correctness here); treat as non-blocking and
+        #   surface the status so a human can sanity-check.
+        if r.status_code in (200, 204):
+            print(f"OK    {label:30s} {path}  {r.status_code}")
+        elif r.status_code in (403, 501):
+            code = ""
+            try:
+                code = r.json().get("error", {}).get("code", "")
+            except Exception:
+                pass
+            print(f"FAIL  {label:30s} {path}  {r.status_code} {code}")
+            failures.append(label)
+        else:
+            print(f"SKIP  {label:30s} {path}  {r.status_code} (non-blocking)")
+
+    print()
+    if failures:
+        print(
+            f"{len(failures)} endpoint(s) FAILED: {', '.join(failures)}. "
+            "Tools backed by these endpoints will not work on this account. "
+            "Do not release until resolved."
+        )
+        return 1
+    print(f"All {len(ENDPOINTS)} endpoints reachable. Safe to tag.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
## Why

v1.7.0 shipped four tools backed by `/me/mailboxSettings/*` that Microsoft Graph doesn't support on personal accounts. Unit tests passed (SDK mocked). The bug surfaced only when an actual tool call returned 403. v1.7.1 yanked the tools.

This adds a 30-second curl-style smoke test against the live Graph API, intended to run before tagging any release, so the next time someone adds a tool backed by a not-supported endpoint we catch it locally instead of on PyPI.

## What

- **`scripts/preflight.py`** — uses the locally-cached token to GET every Graph endpoint family the tools depend on. 200/204 = OK; 403/501 = FAIL (the signal we care about); other 4xx = SKIP/non-blocking. Exits non-zero on any FAIL.
- **`RELEASING.md`** — documents the full release checklist with the smoke test as step 1.
- **`CLAUDE.md`** — adds the preflight command to the Commands section.

## Sanity check

Ran against a live personal Outlook.com mailbox:

```
OK    Auth / whoami                  me  200
OK    Mail read / search             me/messages?$top=1  200
OK    Mail folders                   me/mailFolders?$top=1  200
OK    Drafts                         me/mailFolders/drafts/messages?$top=1  200
OK    Calendar read                  me/events?$top=1  200
OK    Calendar list                  me/calendars  200
OK    Contacts                       me/contacts?$top=1  200
OK    To Do                          me/todo/lists  200
OK    Focused Inbox overrides        me/inferenceClassification/overrides  200
OK    Categories                     me/outlook/masterCategories  200

All 10 endpoints reachable. Safe to tag.
```

Confirmed it would have caught v1.7.0: adding `me/mailboxSettings/timeZone` to `ENDPOINTS` returns 403 ErrorAccessDenied, which the script flags as FAIL.

## Test plan

- [x] Lint clean (`ruff check scripts/`).
- [x] Unit test suite unchanged (432 pass, 6 skip, 1 pre-existing SOCKS).
- [x] Live run on a personal Outlook.com account passes all 10 endpoints.
- [ ] Future: when a new tool is added backed by a new Graph endpoint family, add a row to `ENDPOINTS`.

Generated with [Claude Code](https://claude.com/claude-code)