### PR TITLE
Add regression tests for the preflight unsupported-endpoint classifier

### DIFF
--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -53,6 +53,22 @@ ENDPOINTS: list[tuple[str, str]] = [
 ]
 
 
+def classify(status_code: int) -> str:
+    """Map an HTTP status from Graph to a preflight verdict.
+
+    - ``"OK"`` (200, 204) — endpoint is supported and the request succeeded.
+    - ``"FAIL"`` (403, 501) — the v1.7.0-class signal: endpoint not supported
+      for this account type, or scopes are wrong. Release blocker.
+    - ``"SKIP"`` (anything else) — 4xx query-shape, 401 transient auth, 429
+      rate-limit, 5xx transient. Surface to a human but don't block release.
+    """
+    if status_code in (200, 204):
+        return "OK"
+    if status_code in (403, 501):
+        return "FAIL"
+    return "SKIP"
+
+
 def fetch_token() -> str:
     config = load_config()
     am = AuthManager(config)
@@ -82,15 +98,10 @@ def run() -> int:
             failures.append(label)
             continue
 
-        # 200/204: endpoint is supported and the request succeeded.
-        # 403/501: the failures we exist to catch — endpoint isn't
-        #   supported for this account type, or scopes are wrong.
-        # 4xx other: usually a query-shape issue (we're not testing
-        #   request correctness here); treat as non-blocking and
-        #   surface the status so a human can sanity-check.
-        if r.status_code in (200, 204):
+        verdict = classify(r.status_code)
+        if verdict == "OK":
             print(f"OK    {label:30s} {path}  {r.status_code}")
-        elif r.status_code in (403, 501):
+        elif verdict == "FAIL":
             code = ""
             try:
                 code = r.json().get("error", {}).get("code", "")

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,81 @@
+"""Regression tests for scripts/preflight.py.
+
+The preflight script's entire purpose is to catch the v1.7.0-class bug:
+a tool ships against a Graph endpoint that's documented as supported
+but actually returns 403 / 501 / "not supported" on the target account
+type (personal Outlook.com). These tests lock in the classifier so a
+future refactor can't silently weaken the release-gate.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+
+_PREFLIGHT_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent / "scripts" / "preflight.py"
+)
+_spec = importlib.util.spec_from_file_location("preflight", _PREFLIGHT_PATH)
+preflight = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(preflight)
+
+
+class TestClassify:
+    def test_200_is_ok(self):
+        assert preflight.classify(200) == "OK"
+
+    def test_204_is_ok(self):
+        assert preflight.classify(204) == "OK"
+
+    def test_403_is_fail_v170_regression(self):
+        """v1.7.0 regression: /me/mailboxSettings returned 403
+        ErrorAccessDenied on personal Microsoft accounts. The preflight
+        MUST flag 403 as FAIL so this class of bug blocks the release
+        ritual instead of shipping to PyPI / ClawHub / MCP registry."""
+        assert preflight.classify(403) == "FAIL"
+
+    def test_501_is_fail(self):
+        """Some Graph paths return 501 NotImplemented for unsupported
+        account types — same release-blocker family as 403."""
+        assert preflight.classify(501) == "FAIL"
+
+    def test_400_is_skip_query_shape(self):
+        assert preflight.classify(400) == "SKIP"
+
+    def test_401_is_skip_token_issue(self):
+        assert preflight.classify(401) == "SKIP"
+
+    def test_404_is_skip_resource_id(self):
+        assert preflight.classify(404) == "SKIP"
+
+    def test_429_is_skip_rate_limit(self):
+        assert preflight.classify(429) == "SKIP"
+
+    def test_500_is_skip_transient_server_error(self):
+        assert preflight.classify(500) == "SKIP"
+
+    def test_502_is_skip_transient_server_error(self):
+        assert preflight.classify(502) == "SKIP"
+
+
+class TestEndpointsList:
+    def test_mailbox_settings_endpoints_not_present(self):
+        """v1.7.0 regression guard: /me/mailboxSettings/* tools were
+        yanked in 1.7.1 because Graph doesn't support the resource on
+        personal accounts. If a future commit re-adds an endpoint under
+        that path to ENDPOINTS, this test fails so we revisit the
+        decision (see ROADMAP "Investigated and not viable")."""
+        for path, _label in preflight.ENDPOINTS:
+            assert "mailboxSettings" not in path, (
+                f"Endpoint {path!r} is in the preflight list, but "
+                "/me/mailboxSettings/* is not supported on personal "
+                "accounts (see ROADMAP and CHANGELOG 1.7.1). Re-investigate "
+                "before re-adding."
+            )
+
+    def test_includes_inference_overrides(self):
+        """Phase 3 of v1.7.0 added the override CRUD tools; the preflight
+        must continue exercising that endpoint."""
+        paths = [p for p, _ in preflight.ENDPOINTS]
+        assert any("inferenceClassification/overrides" in p for p in paths)


### PR DESCRIPTION
## Why

The v1.7.0 → v1.7.1 cycle added \`scripts/preflight.py\` to catch the "Graph endpoint not supported on this account type" class of bug at release time. The script's correctness is now itself release-gating, so a future refactor that silently weakened it (e.g. treating 403 as "skip" because a contributor saw too many false-positives) would re-open the v1.7.0 failure mode.

This PR locks the classifier behavior with explicit tests, including a regression test that ties \`classify(403) == "FAIL"\` directly to the v1.7.0 incident.

## What

- Extract the status-code branching out of \`preflight.run()\` into a named \`classify(status_code) -> str\` function. Zero behavior change.
- New \`tests/test_preflight.py\` (12 tests):
  - \`TestClassify\` — every relevant status code (200, 204, 400, 401, 403, 404, 429, 500, 501, 502). The 403 test names the v1.7.0 regression in its docstring.
  - \`TestEndpointsList\` — guards that \`/me/mailboxSettings/*\` doesn't reappear in the script's ENDPOINTS list (the v1.7.0 dead-end documented in ROADMAP), and that the inference-override endpoint stays covered.

The test loads \`scripts/preflight.py\` via \`importlib\` so the \`scripts/\` dir doesn't need to become a package or land on \`sys.path\`.

## Test plan

- [x] \`uv run pytest tests/test_preflight.py -v\` → 12/12 pass.
- [x] \`uv run pytest --tb=no -q\` → 444 pass (was 432, +12), 6 skip, 1 pre-existing SOCKS env failure.
- [x] \`uv run python scripts/preflight.py\` against a live personal Outlook.com mailbox → 10/10 OK after refactor.
- [x] \`uv run ruff check src/ tests/ scripts/\` clean.

Generated with [Claude Code](https://claude.com/claude-code)