### PR TITLE
v1.9.0: delta queries (3 new tools, stacked on v1.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to outlook-graph-mcp are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] — 2026-05-21
+
+### Added — Delta queries (3 tools)
+
+Wraps Microsoft Graph's `$delta` endpoints. The use case: an agent's
+recurring poll (morning brief, hourly inbox check) currently re-fetches
+the last N messages on every run, even when nothing changed. With delta
+queries the second-and-later call returns only what changed since the
+last token — typically 0–3 items on a stable inbox. Real money on
+per-token billing for recurring agent jobs.
+
+- `outlook_list_inbox_delta(folder="inbox", page_size=50, delta_token=None)`
+  — wraps `GET /me/mailFolders/{folder}/messages/delta`.
+- `outlook_list_events_delta(start, end, page_size=50, delta_token=None)`
+  — wraps `GET /me/calendarView/delta`. `start` and `end` (ISO 8601) are
+  required on the first call; ignored on follow-ups (the cursor encodes
+  the window).
+- `outlook_list_contacts_delta(page_size=50, delta_token=None)` — wraps
+  `GET /me/contacts/delta`.
+
+**Cursor semantics.** The `delta_token` is opaque to the caller (it's
+the deltaLink or nextLink URL Graph hands back, passed through as a
+string). outlook-mcp does *not* persist tokens server-side — the agent
+stores its own watermark and replays it. Matches the existing
+pagination `cursor` pattern.
+
+**Tombstones.** Deleted items come back as `{id, is_deleted: True}`
+with no other fields. Agents should treat them as cache evictions.
+Live items also carry `is_deleted: False` for symmetry.
+
+**Cap behavior.** Each call auto-follows `@odata.nextLink` internally
+up to `page_size * 4` items, then stops with `has_more: True` and the
+nextLink as the returned `delta_token` so the caller can resume. This
+keeps a single tool call bounded even on a large first-call snapshot
+(e.g. ~12k contacts).
+
+**Verified working on personal accounts via the preflight script** —
+the three new delta endpoints are reachable from `/me/...` on
+outlook.com mailboxes without additional consent scopes.
+
+### Tool count
+- 1.8.0 → 1.9.0: **57 → 60 tools, 13 categories** (no new category).
+
 ## [1.8.0] — 2026-05-21
 
 ### Added — Agent-friendly shape

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ Works with any MCP client (OpenClaw, Claude Code, Cursor).
   - `user.py` — User profile, calendars
   - `admin.py` — Categories, mail tips
   - `inference_overrides.py` — Focused Inbox per-sender override CRUD
+  - `mail_delta.py` — Mail delta-sync queries (`outlook_list_inbox_delta`)
+  - `calendar_delta.py` — Calendar delta-sync queries (`outlook_list_events_delta`)
+  - `contacts_delta.py` — Contacts delta-sync queries (`outlook_list_contacts_delta`)
+  - `_delta.py` — Shared httpx-backed delta helper (raw HTTP bypasses the SDK)
 - `src/outlook_mcp/models/` — Pydantic models for I/O
 
 ## Conventions

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You'll like this if you're:
 - Looking for **real coverage** — mail, calendar, contacts, to-do, drafts, folders, batch ops, threading — instead of a mail-only or calendar-only wrapper
 - Security-conscious: tokens in the OS keyring (Keychain on macOS), granular `allow_categories`, optional `read_only` mode, zero telemetry
 
-This **isn't for you** if you need work/school M365 accounts (use Microsoft's official tooling — Entra ID auth and admin-consent flows are out of scope here), or if a basic mail-only client would suffice (this has 57 tools — way more than you need for "read my inbox").
+This **isn't for you** if you need work/school M365 accounts (use Microsoft's official tooling — Entra ID auth and admin-consent flows are out of scope here), or if a basic mail-only client would suffice (this has 60 tools — way more than you need for "read my inbox").
 
 ### How it differs from other Outlook tools you'll find
 
@@ -44,7 +44,7 @@ Give your AI agent full Outlook access. Example prompts that just work:
 - *"Draft a reply to the last message from my sister saying I'll call her this weekend."*
 - *"Move all newsletter and promotional email from this week to a 'Read Later' folder — batch 20 at a time."*
 
-The server exposes 57 discrete tools so the agent can compose its own workflow — read, triage, write, schedule, track tasks — without hardcoded macros.
+The server exposes 60 discrete tools so the agent can compose its own workflow — read, triage, write, schedule, track tasks — without hardcoded macros.
 
 ## Works With
 
@@ -59,15 +59,15 @@ Listed on the [official MCP Registry](https://registry.modelcontextprotocol.io/v
 
 ## Features
 
-**57 tools** across 13 categories:
+**60 tools** across 13 categories:
 
 - **Auth (1)** -- auth status check (login is via CLI)
-- **Mail Read (4)** -- list inbox (with Focused Inbox filter), read message, search (KQL), list folders
+- **Mail Read (5)** -- list inbox (with Focused Inbox filter), read message, search (KQL), list folders, delta-sync inbox changes
 - **Mail Write (3)** -- send, reply/reply-all, forward
 - **Mail Triage (9)** -- move, delete (soft by default), flag, categorize, mark read/unread, reclassify (Focused Inbox), list/set/delete per-sender Focused Inbox overrides
-- **Calendar Read (2)** -- list events (with recurring expansion), get event details
+- **Calendar Read (3)** -- list events (with recurring expansion), get event details, delta-sync event changes
 - **Calendar Write (4)** -- create, update, delete, RSVP (accept/decline/tentative)
-- **Contacts (6)** -- list, search, get, create, update, delete
+- **Contacts (7)** -- list, search, get, create, update, delete, delta-sync changes
 - **To Do (6)** -- list task lists, list/create/update/complete/delete tasks
 - **Drafts (5)** -- list, create, update, send, delete
 - **Attachments (5)** -- list, download, send-with-attachments, attach-to-draft, remove-draft-attachment
@@ -244,6 +244,7 @@ uv run outlook-mcp serve    # Start MCP server (default, used by OpenClaw/Claude
 | `outlook_read_message` | Get full message by ID. Format: `text`, `html`, or `full` (both). Pass `include_deferred_send=True` to also surface the draft's scheduled delivery time. |
 | `outlook_search_mail` | Search mail using KQL query. Optionally scope to a folder by name or ID. |
 | `outlook_list_folders` | List mail folders with counts, `parent_id`, and `child_count`. Pass `recursive=true` to walk the full folder tree (subfolders included). |
+| `outlook_list_inbox_delta` | List only inbox changes since the last call. First call returns a full snapshot plus a `delta_token`; subsequent calls (token passed back) return only added/updated/deleted items. Deletes come back as `{id, is_deleted: True}`. Cursor is stateless — agent persists and replays. |
 
 ### Mail Write
 
@@ -273,6 +274,7 @@ uv run outlook-mcp serve    # Start MCP server (default, used by OpenClaw/Claude
 |------|-------------|
 | `outlook_list_events` | List events in a date range. Expands recurring events. Configurable via `days`, `after`, `before`. |
 | `outlook_get_event` | Get full event details: attendees, body, online meeting URL, recurrence. |
+| `outlook_list_events_delta` | List only event changes inside a window since the last call. `start` and `end` (ISO 8601) required on the first call (Graph constraint — no whole-calendar sync). Deletes come back as `{id, is_deleted: True}`. Cursor is stateless. |
 
 ### Calendar Write
 
@@ -293,6 +295,7 @@ uv run outlook-mcp serve    # Start MCP server (default, used by OpenClaw/Claude
 | `outlook_create_contact` | Create a new contact. |
 | `outlook_update_contact` | Update contact fields. |
 | `outlook_delete_contact` | Delete a contact. |
+| `outlook_list_contacts_delta` | List only contact changes since the last call. Deletes come back as `{id, is_deleted: True}`. Cursor is stateless. |
 
 ### To Do
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,15 +4,6 @@ Planned work for `outlook-graph-mcp`. Items here are committed-to direction; tim
 
 ## Near-term
 
-### Delta queries for `list_inbox` / folder scans
-Swap repeated `/me/mailFolders/inbox/messages` polls for `/me/mailFolders/inbox/messages/delta`. Returns only what changed since the last delta token. Makes recurring agent workflows (morning briefs, daily junk scans, weekly digests) near-free instead of re-fetching 25 messages on every run.
-
-**Shape:** new `outlook_list_inbox_delta` tool (or `delta=true` flag on `list_inbox`) that persists the delta token per-folder in the config dir and returns only new/changed/removed messages on subsequent calls.
-
-**Impact:** 10–100× fewer tokens transferred per poll for stable inboxes. Meaningful for agent cost + latency.
-
----
-
 ### Mail rules CRUD
 Programmatic management of Outlook inbox rules via `/me/mailFolders/inbox/messageRules`. No other MCP I'm aware of exposes this.
 
@@ -39,6 +30,7 @@ Programmatic management of Outlook inbox rules via `/me/mailFolders/inbox/messag
 
 ## Done
 
+- **1.9.0** — Delta queries (3 new tools): `outlook_list_inbox_delta`, `outlook_list_events_delta`, `outlook_list_contacts_delta`. Wraps Graph's `$delta` endpoints. First call returns a snapshot plus an opaque `delta_token`; subsequent calls (token passed back) return only added/updated/deleted items. Tombstones are `{id, is_deleted: True}` with no other fields — agents drop cached payloads cleanly. Stateless cursor (server doesn't persist tokens, matching the existing pagination `cursor` pattern). Per-call safety cap auto-follows `@odata.nextLink` up to `page_size * 4` items, then surfaces `has_more: True` plus the nextLink so the caller resumes. Massive token savings for recurring agent jobs polling a stable inbox/calendar/contacts. Tool count: 57 → 60.
 - **1.8.0** — Agent-friendly shape, pure code. Two upgrades, no new tools: (a) `concise=True` opt-in on the five high-volume read tools (`outlook_list_inbox`, `outlook_read_message`, `outlook_search_mail`, `outlook_list_events`, `outlook_list_thread`) — drops bulky body / attendee / categories / quoted-text fields for ~10× smaller payloads on triage scans; (b) Graph SDK error wrapper that translates `ODataError`/`APIError` into a structured `GraphAPIError(code, message, action)` with recovery hints (re-auth on 401, ROADMAP pointer on 403/`ErrorAccessDenied`, re-list on 404, back-off on 429, retry on 503). Strict backward compat — defaults preserve the existing response shapes.
 - **1.7.1** — Yanked the four mailbox-settings tools added in 1.7.0 (see CHANGELOG). Microsoft Graph's `/me/mailboxSettings` resource isn't supported for personal accounts, which is the project's only target. Auth timeout raised from 5 to 15 minutes.
 - **1.7.0** — Focused Inbox per-sender override CRUD (upsert by sender, case-insensitive match): `outlook_list_inbox_overrides`, `outlook_set_inbox_override`, `outlook_delete_inbox_override`. Tool count: 54 → 57.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: outlook-mcp
-description: Production-grade MCP server for personal Outlook (Outlook.com / Hotmail / Live). 57 typed Graph tools across mail, calendar, contacts, to-do, drafts, attachments, folders, threading, batch ops. Granular permissions, OS-keyring auth, /$batch-optimized triage. Built for agents that need real Outlook coverage, not a CLI wrapper. BYO Azure app; zero telemetry.
+description: Production-grade MCP server for personal Outlook (Outlook.com / Hotmail / Live). 60 typed Graph tools across mail, calendar, contacts, to-do, drafts, attachments, folders, threading, batch ops, delta-sync. Granular permissions, OS-keyring auth, /$batch-optimized triage. Built for agents that need real Outlook coverage, not a CLI wrapper. BYO Azure app; zero telemetry.
 homepage: https://github.com/mpalermiti/outlook-mcp
 metadata:
   openclaw:
@@ -56,7 +56,7 @@ Pass `concise=True` to read tools (`outlook_list_inbox`, `outlook_read_message`,
    ```
 6. **Restart the gateway:** `openclaw gateway restart`
 
-## Tools (57)
+## Tools (60)
 
 ### Auth
 - `outlook_auth_status` — Check authentication status and read-only mode
@@ -66,6 +66,7 @@ Pass `concise=True` to read tools (`outlook_list_inbox`, `outlook_read_message`,
 - `outlook_read_message` — Get full message by ID
 - `outlook_search_mail` — Search mail using KQL query
 - `outlook_list_folders` — List all mail folders
+- `outlook_list_inbox_delta` — List only inbox changes since last call (massive token savings for recurring agent jobs)
 
 ### Mail — Write
 - `outlook_send_message` — Send email with recipients, CC, BCC, HTML, importance
@@ -86,6 +87,7 @@ Pass `concise=True` to read tools (`outlook_list_inbox`, `outlook_read_message`,
 ### Calendar
 - `outlook_list_events` — List events in date range (expands recurring)
 - `outlook_get_event` — Get event details
+- `outlook_list_events_delta` — List only event changes since last call within a window (massive token savings for recurring agent jobs)
 - `outlook_create_event` — Create event with attendees, recurrence, online meeting
 - `outlook_update_event` — Update event fields
 - `outlook_delete_event` — Delete event
@@ -98,6 +100,7 @@ Pass `concise=True` to read tools (`outlook_list_inbox`, `outlook_read_message`,
 - `outlook_create_contact` — Create
 - `outlook_update_contact` — Update
 - `outlook_delete_contact` — Delete
+- `outlook_list_contacts_delta` — List only contact changes since last call (massive token savings for recurring agent jobs)
 
 ### To Do
 - `outlook_list_task_lists` — List To Do lists

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "outlook-graph-mcp"
-version = "1.8.0"
+version = "1.9.0"
 description = "MCP server for Microsoft Outlook via Microsoft Graph API"
 readme = "README.md"
 license = "MIT"

--- a/scripts/preflight.py
+++ b/scripts/preflight.py
@@ -50,6 +50,13 @@ ENDPOINTS: list[tuple[str, str]] = [
     ("me/todo/lists", "To Do"),
     ("me/inferenceClassification/overrides", "Focused Inbox overrides"),
     ("me/outlook/masterCategories", "Categories"),
+    ("me/mailFolders/inbox/messages/delta", "Mail delta"),
+    (
+        "me/calendarView/delta?startDateTime=2026-05-21T00:00:00Z"
+        "&endDateTime=2026-05-28T00:00:00Z",
+        "Calendar delta",
+    ),
+    ("me/contacts/delta", "Contacts delta"),
 ]
 
 

--- a/server.json
+++ b/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.mpalermiti/outlook-mcp",
   "title": "Outlook MCP",
-  "description": "Microsoft Outlook personal accounts: mail, calendar, contacts, to-do, drafts (57 tools).",
-  "version": "1.8.0",
+  "description": "Microsoft Outlook personal accounts: mail, calendar, contacts, to-do, drafts (60 tools).",
+  "version": "1.9.0",
   "websiteUrl": "https://github.com/mpalermiti/outlook-mcp",
   "repository": {
     "url": "https://github.com/mpalermiti/outlook-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "outlook-graph-mcp",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/outlook_mcp/graph.py
+++ b/src/outlook_mcp/graph.py
@@ -26,3 +26,9 @@ class GraphClient:
         )
         request_adapter = GraphRequestAdapter(auth_provider)
         self.sdk_client = GraphServiceClient(request_adapter=request_adapter)
+        # Retained so delta-query tools can mint raw bearer tokens for direct
+        # httpx calls to Graph's *delta endpoints — the SDK's typed delta
+        # builders rebuild URL templates from query-parameter dataclasses and
+        # silently drop the ``@removed`` annotation we need to surface to
+        # callers, so the delta module bypasses the SDK.
+        self.credential = credential

--- a/src/outlook_mcp/server.py
+++ b/src/outlook_mcp/server.py
@@ -17,9 +17,11 @@ from outlook_mcp.graph import GraphClient
 from outlook_mcp.tools import (
     admin,
     batch,
+    calendar_delta,
     calendar_read,
     calendar_write,
     contacts,
+    contacts_delta,
     inference_overrides,
     mail_attachments,
     mail_delta,
@@ -518,6 +520,31 @@ async def outlook_get_event(
     return await calendar_read.get_event(client.sdk_client, event_id)
 
 
+@mcp.tool()
+@_wrap_tool_errors
+async def outlook_list_events_delta(
+    ctx: Context,
+    start: str | None = None,
+    end: str | None = None,
+    page_size: int = 50,
+    delta_token: str | None = None,
+) -> dict:
+    """List only calendar events that changed since the last call.
+
+    Graph's ``/me/calendarView/delta`` requires an explicit
+    ``[start, end]`` ISO 8601 window on the first call — there's no
+    whole-calendar sync, only windowed deltas. Subsequent calls
+    (with ``delta_token``) reuse the window encoded in the cursor;
+    ``start`` / ``end`` may be omitted then.
+
+    Deleted events return as ``{id, is_deleted: True}`` with no other
+    fields. When ``has_more=True`` pass the returned ``delta_token``
+    back immediately to keep draining the round.
+    """
+    client = _get_graph_client(ctx)
+    return await calendar_delta.list_events_delta(client, start, end, page_size, delta_token)
+
+
 # ── Calendar Write Tools ────────────────────────────────
 
 
@@ -690,6 +717,27 @@ async def outlook_delete_contact(ctx: Context, contact_id: str) -> dict:
     client = _get_graph_client(ctx)
     config = _get_config(ctx)
     return await contacts.delete_contact(client.sdk_client, contact_id, config=config)
+
+
+@mcp.tool()
+@_wrap_tool_errors
+async def outlook_list_contacts_delta(
+    ctx: Context,
+    page_size: int = 50,
+    delta_token: str | None = None,
+) -> dict:
+    """List only contacts that changed since the last call.
+
+    Graph's ``/me/contacts/delta`` accepts no first-call query parameters
+    other than the ``Prefer: odata.maxpagesize=N`` page-size header — the
+    tool wires ``page_size`` to that header and ignores everything else.
+
+    Deleted contacts return as ``{id, is_deleted: True}`` with no other
+    fields. When ``has_more=True`` pass the returned ``delta_token``
+    back immediately to keep draining the round.
+    """
+    client = _get_graph_client(ctx)
+    return await contacts_delta.list_contacts_delta(client, page_size, delta_token)
 
 
 # ── To Do Tools ────────────────────────────────────────

--- a/src/outlook_mcp/server.py
+++ b/src/outlook_mcp/server.py
@@ -22,6 +22,7 @@ from outlook_mcp.tools import (
     contacts,
     inference_overrides,
     mail_attachments,
+    mail_delta,
     mail_drafts,
     mail_folders,
     mail_read,
@@ -232,6 +233,36 @@ async def outlook_list_folders(
     """
     client = _get_graph_client(ctx)
     return await mail_read.list_folders(client.sdk_client, cursor=cursor, recursive=recursive)
+
+
+@mcp.tool()
+@_wrap_tool_errors
+async def outlook_list_inbox_delta(
+    ctx: Context,
+    folder: str = "inbox",
+    page_size: int = 50,
+    delta_token: str | None = None,
+) -> dict:
+    """List only messages that changed since the last call. Stateless cursor.
+
+    First call (no ``delta_token``): full snapshot of ``folder``. Returns a
+    ``delta_token`` you persist on the agent side.
+
+    Subsequent calls (pass that token back): only added/updated/deleted
+    messages since the previous call. Deleted messages return as
+    ``{id, is_deleted: True}`` with no other fields — agents should treat
+    them as tombstones and drop any cached payload.
+
+    When ``has_more=True`` the per-call cap stopped mid-sync; pass the
+    returned ``delta_token`` back immediately to keep draining. When
+    ``delta_token`` comes back ``None`` Graph signaled "no change" — keep
+    using your previous token.
+
+    Massive token savings for recurring agent jobs (morning briefs, hourly
+    polls): a stable inbox returns ~0 messages per call instead of 25.
+    """
+    client = _get_graph_client(ctx)
+    return await mail_delta.list_inbox_delta(client, folder, page_size, delta_token)
 
 
 # ── Mail Write Tools ────────────────────────────────────

--- a/src/outlook_mcp/tools/_delta.py
+++ b/src/outlook_mcp/tools/_delta.py
@@ -1,0 +1,156 @@
+"""Shared helpers for Graph ``$delta`` queries.
+
+These tools deliberately bypass the msgraph SDK and hit Graph's delta
+endpoints with raw httpx. The SDK's typed delta builders rebuild URL
+templates from query-parameter dataclasses (so a deltaLink passed through
+them gets its ``$deltatoken`` stripped) and discard the ``@removed``
+annotation on returned items, which delta-query callers need to detect
+tombstones. Raw httpx is also easier to wire to the per-endpoint quirks
+documented inline:
+
+- ``/me/calendarView/delta`` requires ``startDateTime`` + ``endDateTime``
+  on the first call but rejects ``$top``; you must pass
+  ``Prefer: odata.maxpagesize=N`` instead.
+- ``/me/contacts/delta`` accepts no query string at all on the first call;
+  ``Prefer: odata.maxpagesize=N`` is again how you size the page.
+- ``/me/mailFolders/{id}/messages/delta`` accepts ``$top``.
+
+Tokens are *not* persisted by outlook-mcp — that's the caller's job (an
+agent decides where it wants to store its watermark). We pass the raw
+``@odata.deltaLink`` / ``@odata.nextLink`` URL through as the opaque
+cursor string.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+GRAPH_BASE = "https://graph.microsoft.com/v1.0/"
+GRAPH_TOKEN_SCOPE = "https://graph.microsoft.com/.default"
+
+# Safety cap multiplier — bound a single tool call to at most this many
+# items even when Graph keeps handing us more ``@odata.nextLink`` pages
+# inside one delta-sync round. Callers continue by passing the returned
+# delta_token (a nextLink) back in.
+PAGE_SIZE_CAP_MULTIPLIER = 4
+
+
+def _bearer_token(credential: Any) -> str:
+    """Mint a Graph access token from an azure-identity credential."""
+    tok = credential.get_token(GRAPH_TOKEN_SCOPE)
+    return tok.token
+
+
+def format_delta_item(raw: dict, normal_formatter) -> dict:
+    """Map a raw Graph delta-response item to outlook-mcp's wire shape.
+
+    Items annotated with ``@removed`` are tombstones — Graph returns only
+    the ``id`` (and the annotation), no other fields. We collapse those
+    to ``{id, is_deleted: True}`` so callers don't have to special-case
+    sparse rows.
+
+    Live items go through ``normal_formatter`` (which expects the dict
+    shape Graph sends — *not* an SDK object) and get ``is_deleted: False``
+    appended.
+    """
+    if "@removed" in raw:
+        return {"id": raw.get("id"), "is_deleted": True}
+    out = normal_formatter(raw)
+    out["is_deleted"] = False
+    return out
+
+
+async def fetch_delta_pages(
+    credential: Any,
+    *,
+    initial_url: str,
+    delta_token: str | None,
+    page_size: int,
+    headers: dict[str, str] | None = None,
+    timeout: float = 30.0,
+) -> tuple[list[dict], str | None, bool]:
+    """Walk Graph delta pages until a ``deltaLink`` or the safety cap.
+
+    Behavior:
+
+    - When ``delta_token`` is provided it's used as the request URL
+      verbatim — it's already a full Graph URL (either a deltaLink that
+      starts a new sync round or a nextLink that resumes an in-progress
+      one). ``initial_url`` is ignored in that case.
+    - When ``delta_token`` is ``None`` we hit ``initial_url`` (the
+      caller-built first-sync URL with whatever query params and
+      Prefer headers the resource accepts).
+    - We auto-follow ``@odata.nextLink`` inside a single tool call up to
+      ``page_size * PAGE_SIZE_CAP_MULTIPLIER`` items so an agent isn't
+      forced to chain four follow-up calls just to drain Graph's
+      pagination on a large initial snapshot.
+    - We stop early on the cap and surface ``has_more=True`` plus the
+      nextLink as the returned token so the caller can resume.
+    - We stop on a ``deltaLink`` and surface ``has_more=False`` plus the
+      deltaLink as the returned token — the caller stores that and uses
+      it for the *next* sync round.
+    - If Graph returns neither (rare but valid: zero changes plus no
+      deltaLink, which means the previous token is still valid), we
+      return ``has_more=False`` and ``delta_token=None`` so the caller
+      keeps using their old token.
+
+    Returns ``(raw_items, next_token, has_more)``. ``raw_items`` is the
+    accumulated list of dicts straight from Graph; the per-resource
+    wrapper is responsible for mapping them through ``format_delta_item``
+    with the right per-item formatter.
+    """
+    if page_size < 1:
+        page_size = 1
+    cap = page_size * PAGE_SIZE_CAP_MULTIPLIER
+
+    url: str = delta_token if delta_token else initial_url
+    base_headers = {
+        "Authorization": f"Bearer {_bearer_token(credential)}",
+        "Accept": "application/json",
+    }
+    if headers:
+        base_headers.update(headers)
+
+    collected: list[dict] = []
+    next_token: str | None = None
+    has_more = False
+
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        while True:
+            r = await client.get(url, headers=base_headers)
+            r.raise_for_status()
+            body = r.json()
+
+            page_items = body.get("value") or []
+            collected.extend(page_items)
+
+            next_link = body.get("@odata.nextLink")
+            delta_link = body.get("@odata.deltaLink")
+
+            if delta_link:
+                # Reached the end of this sync round. The deltaLink is the
+                # cursor for the *next* round.
+                next_token = delta_link
+                has_more = False
+                break
+
+            if next_link:
+                if len(collected) >= cap:
+                    # Hit the per-call cap mid-sync. Hand the nextLink back
+                    # so the caller resumes from where we stopped.
+                    next_token = next_link
+                    has_more = True
+                    break
+                url = next_link
+                continue
+
+            # Neither link present — possible on the no-changes path when
+            # Graph echoes the old window without a new deltaLink. Caller
+            # should reuse their previous token.
+            next_token = None
+            has_more = False
+            break
+
+    return collected, next_token, has_more

--- a/src/outlook_mcp/tools/calendar_delta.py
+++ b/src/outlook_mcp/tools/calendar_delta.py
@@ -1,0 +1,122 @@
+"""Calendar delta tool: ``list_events_delta``.
+
+Wraps ``GET /me/calendarView/delta``.
+
+Graph constraints worth knowing before reading the code:
+
+- ``startDateTime`` + ``endDateTime`` are *required* on the first call —
+  unlike ``/me/messages/delta`` there is no whole-mailbox sync, only
+  windowed deltas. We validate both at the boundary so a missing arg
+  fails fast as ``ValueError`` (passed through by the tool wrapper).
+- ``$top`` is rejected with a 400. Page sizing is via the
+  ``Prefer: odata.maxpagesize=N`` header instead.
+- Subsequent calls use the returned deltaLink / nextLink URL verbatim —
+  Graph encodes the window in the cursor.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote, urljoin
+
+from outlook_mcp.tools._delta import GRAPH_BASE, fetch_delta_pages, format_delta_item
+from outlook_mcp.validation import sanitize_output, validate_datetime
+
+
+def _clamp(value: int, low: int, high: int) -> int:
+    return max(low, min(high, value))
+
+
+def _format_event_delta(raw: dict) -> dict:
+    """Build the wire-shape event summary from a raw Graph JSON event.
+
+    Mirrors ``calendar_read._format_event_summary`` field-for-field so
+    callers don't have to branch on whether a given dict came from a
+    delta call or a regular list call.
+    """
+    start_node = raw.get("start") or {}
+    end_node = raw.get("end") or {}
+    organizer_node = (raw.get("organizer") or {}).get("emailAddress") or {}
+    response_node = raw.get("responseStatus") or {}
+    location_node = raw.get("location") or {}
+
+    start_str = ""
+    if start_node:
+        start_str = f"{start_node.get('dateTime', '')} ({start_node.get('timeZone', '')})"
+    end_str = ""
+    if end_node:
+        end_str = f"{end_node.get('dateTime', '')} ({end_node.get('timeZone', '')})"
+
+    return {
+        "id": raw.get("id"),
+        "subject": sanitize_output(raw.get("subject") or "(no subject)"),
+        "start": start_str,
+        "end": end_str,
+        "location": sanitize_output(location_node.get("displayName") or ""),
+        "is_all_day": bool(raw.get("isAllDay")),
+        "organizer": sanitize_output(organizer_node.get("name") or ""),
+        "response_status": response_node.get("response") or "",
+        "is_online": bool(raw.get("isOnlineMeeting")),
+    }
+
+
+async def list_events_delta(
+    graph_client: Any,
+    start: str | None,
+    end: str | None,
+    page_size: int = 50,
+    delta_token: str | None = None,
+) -> dict:
+    """List calendar-view changes within ``[start, end]`` since the last token.
+
+    Args:
+        graph_client: A ``GraphClient`` (delta tools need the
+            ``credential`` attribute to mint raw bearer tokens).
+        start: ISO 8601 window start. **Required** on the first call;
+            ignored when ``delta_token`` is set (the cursor already
+            encodes the window).
+        end: ISO 8601 window end. Same as ``start``.
+        page_size: Items per Graph page (1-100). Mapped to
+            ``Prefer: odata.maxpagesize=N`` — Graph rejects ``$top`` on
+            this endpoint.
+        delta_token: Opaque cursor from a previous call.
+
+    Returns:
+        ``{events, delta_token, has_more}`` — see ``mail_delta`` for the
+        full semantics of these fields. Tombstones come back as
+        ``{id, is_deleted: True}``.
+    """
+    page_size = _clamp(page_size, 1, 100)
+    credential = graph_client.credential
+
+    initial_url = ""
+    if not delta_token:
+        if not start or not end:
+            raise ValueError(
+                "outlook_list_events_delta requires both 'start' and 'end' "
+                "(ISO 8601 datetimes) on the first call — Graph's "
+                "/me/calendarView/delta endpoint has no whole-calendar sync."
+            )
+        safe_start = validate_datetime(start)
+        safe_end = validate_datetime(end)
+        initial_url = urljoin(GRAPH_BASE, "me/calendarView/delta")
+        initial_url = (
+            f"{initial_url}?startDateTime={quote(safe_start, safe='')}"
+            f"&endDateTime={quote(safe_end, safe='')}"
+        )
+
+    raw_items, next_token, has_more = await fetch_delta_pages(
+        credential,
+        initial_url=initial_url,
+        delta_token=delta_token,
+        page_size=page_size,
+        headers={"Prefer": f"odata.maxpagesize={page_size}"},
+    )
+
+    events = [format_delta_item(item, _format_event_delta) for item in raw_items]
+
+    return {
+        "events": events,
+        "delta_token": next_token,
+        "has_more": has_more,
+    }

--- a/src/outlook_mcp/tools/contacts_delta.py
+++ b/src/outlook_mcp/tools/contacts_delta.py
@@ -1,0 +1,115 @@
+"""Contacts delta tool: ``list_contacts_delta``.
+
+Wraps ``GET /me/contacts/delta``.
+
+Graph constraints worth knowing before reading the code:
+
+- This endpoint accepts **no query parameters at all** on the first
+  call — confirmed by a curl 400 against the live API. Page sizing is
+  via the ``Prefer: odata.maxpagesize=N`` header only.
+- Subsequent calls use the returned deltaLink / nextLink URL verbatim
+  (Graph's encoded URL is fine; we don't try to strip or augment query
+  params on it).
+
+To keep the surface predictable we just don't take any first-call query
+arguments here. There's nothing to strip and no client-side validation
+needed beyond ``page_size``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urljoin
+
+from outlook_mcp.tools._delta import GRAPH_BASE, fetch_delta_pages, format_delta_item
+from outlook_mcp.validation import sanitize_output
+
+
+def _clamp(value: int, low: int, high: int) -> int:
+    return max(low, min(high, value))
+
+
+def _primary_phone_from_dict(raw: dict) -> str:
+    """Pick the most representative phone from a raw Graph contact dict.
+
+    Mirrors ``contacts._primary_phone`` — consumer Outlook accounts
+    expose ``mobilePhone`` (single), ``homePhones`` (list), and
+    ``businessPhones`` (list). Prefer mobile, then first home, then
+    first business.
+    """
+    mobile = raw.get("mobilePhone") or ""
+    if mobile:
+        return mobile
+    for key in ("homePhones", "businessPhones"):
+        values = raw.get(key) or []
+        if values:
+            return values[0]
+    return ""
+
+
+def _format_contact_delta(raw: dict) -> dict:
+    """Build the wire-shape contact summary from a raw Graph JSON contact.
+
+    Mirrors ``contacts._format_contact_summary`` field-for-field so
+    callers don't have to branch on whether a given dict came from a
+    delta call or a regular list call.
+    """
+    email = ""
+    emails = raw.get("emailAddresses") or []
+    if emails:
+        email = emails[0].get("address") or ""
+
+    return {
+        "id": raw.get("id"),
+        "display_name": sanitize_output(raw.get("displayName") or ""),
+        "email": email,
+        "phone": _primary_phone_from_dict(raw),
+        "company": sanitize_output(raw.get("companyName") or ""),
+    }
+
+
+async def list_contacts_delta(
+    graph_client: Any,
+    page_size: int = 50,
+    delta_token: str | None = None,
+) -> dict:
+    """List contact changes since the last delta token.
+
+    Args:
+        graph_client: A ``GraphClient`` (delta tools need the
+            ``credential`` attribute to mint raw bearer tokens).
+        page_size: Items per Graph page (1-100). Mapped to
+            ``Prefer: odata.maxpagesize=N`` — Graph rejects every other
+            query parameter on this endpoint.
+        delta_token: Opaque cursor from a previous call.
+
+    Returns:
+        ``{contacts, delta_token, has_more}`` — see ``mail_delta`` for
+        full semantics. Tombstones come back as
+        ``{id, is_deleted: True}``.
+    """
+    page_size = _clamp(page_size, 1, 100)
+    credential = graph_client.credential
+
+    initial_url = ""
+    if not delta_token:
+        # /me/contacts/delta accepts no query params — Graph 400s if you
+        # even pass a $select. The page size header below is the only
+        # knob we get.
+        initial_url = urljoin(GRAPH_BASE, "me/contacts/delta")
+
+    raw_items, next_token, has_more = await fetch_delta_pages(
+        credential,
+        initial_url=initial_url,
+        delta_token=delta_token,
+        page_size=page_size,
+        headers={"Prefer": f"odata.maxpagesize={page_size}"},
+    )
+
+    contacts = [format_delta_item(item, _format_contact_delta) for item in raw_items]
+
+    return {
+        "contacts": contacts,
+        "delta_token": next_token,
+        "has_more": has_more,
+    }

--- a/src/outlook_mcp/tools/mail_delta.py
+++ b/src/outlook_mcp/tools/mail_delta.py
@@ -1,0 +1,135 @@
+"""Mail delta tool: ``list_inbox_delta``.
+
+Wraps ``GET /me/mailFolders/{folder}/messages/delta``.
+
+First call (no ``delta_token``): full snapshot of the folder. Subsequent
+calls (with ``delta_token``): only messages changed since that token. See
+``_delta.py`` for the cursor/cap semantics that are shared with the
+calendar and contacts delta tools.
+
+Tokens are *not* persisted server-side. The caller (typically an agent
+running on a schedule) stores the returned ``delta_token`` and passes it
+back on the next call. Pattern matches the existing pagination ``cursor``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote, urljoin
+
+from outlook_mcp.folder_resolver import resolve_folder_id
+from outlook_mcp.tools._delta import GRAPH_BASE, fetch_delta_pages, format_delta_item
+from outlook_mcp.validation import sanitize_output
+
+
+def _clamp(value: int, low: int, high: int) -> int:
+    return max(low, min(high, value))
+
+
+def _addr_pair(node: dict | None) -> tuple[str, str]:
+    """Extract (email, name) from a Graph ``recipient`` JSON node."""
+    if not node:
+        return "", ""
+    ea = node.get("emailAddress") or {}
+    return ea.get("address") or "", ea.get("name") or ""
+
+
+def _flag_status(node: dict | None) -> str:
+    if not node:
+        return "notFlagged"
+    return node.get("flagStatus") or "notFlagged"
+
+
+def _format_message_delta(raw: dict) -> dict:
+    """Build the wire-shape message summary from a raw Graph JSON message.
+
+    Mirrors ``mail_read._format_message_summary`` field-for-field so
+    callers don't have to branch on whether a given dict came from a
+    delta call or a regular list call. Extra ``@`` annotations on the
+    Graph response (e.g. ``@odata.etag``) are ignored.
+    """
+    from_email, from_name = _addr_pair(raw.get("from"))
+
+    return {
+        "id": raw.get("id"),
+        "subject": sanitize_output(raw.get("subject") or "(no subject)"),
+        "from_email": from_email,
+        "from_name": sanitize_output(from_name),
+        "received": raw.get("receivedDateTime") or "",
+        "is_read": bool(raw.get("isRead")),
+        "importance": raw.get("importance") or "normal",
+        "preview": sanitize_output(raw.get("bodyPreview") or ""),
+        "has_attachments": bool(raw.get("hasAttachments")),
+        "categories": list(raw.get("categories") or []),
+        "flag": _flag_status(raw.get("flag")),
+        "conversation_id": raw.get("conversationId") or "",
+        "classification": raw.get("inferenceClassification") or "",
+    }
+
+
+async def list_inbox_delta(
+    graph_client: Any,
+    folder: str = "inbox",
+    page_size: int = 50,
+    delta_token: str | None = None,
+) -> dict:
+    """List inbox (or any folder) changes since the last delta token.
+
+    Args:
+        graph_client: A ``GraphClient`` instance (delta tools need the
+            ``credential`` attribute to mint raw bearer tokens — the SDK
+            client is only used for folder name resolution on the first
+            call).
+        folder: Folder display name, well-known name, or Graph ID.
+            Defaults to ``"inbox"``. Ignored when ``delta_token`` is set;
+            the token already encodes the folder.
+        page_size: Items per Graph page (1-100). Mapped to ``$top``.
+        delta_token: Opaque cursor from a previous call. ``None`` on the
+            first call.
+
+    Returns:
+        ``{messages, delta_token, has_more}`` where:
+
+        - ``messages`` is the list of changed-message summaries. Live
+          items use the same shape as ``outlook_list_inbox`` plus an
+          ``is_deleted: False`` field. Tombstones are
+          ``{id, is_deleted: True}`` — *no other fields* on a delete.
+        - ``delta_token`` is either a new opaque cursor (continue
+          syncing later) or ``None`` (no change since the previous
+          token — the caller should reuse it).
+        - ``has_more`` is ``True`` when the per-call safety cap stopped
+          us mid-sync (the caller should pass ``delta_token`` back
+          immediately to keep draining), ``False`` when the round is
+          complete.
+    """
+    page_size = _clamp(page_size, 1, 100)
+
+    sdk_client = graph_client.sdk_client
+    credential = graph_client.credential
+
+    initial_url = ""
+    if not delta_token:
+        # Only resolve the folder name on the first call — subsequent
+        # calls reuse the deltaLink/nextLink URL Graph handed us, which
+        # already contains the folder ID.
+        folder_id = await resolve_folder_id(sdk_client, folder)
+        initial_url = urljoin(
+            GRAPH_BASE,
+            f"me/mailFolders/{quote(folder_id, safe='')}/messages/delta",
+        )
+        initial_url = f"{initial_url}?$top={page_size}"
+
+    raw_items, next_token, has_more = await fetch_delta_pages(
+        credential,
+        initial_url=initial_url,
+        delta_token=delta_token,
+        page_size=page_size,
+    )
+
+    messages = [format_delta_item(item, _format_message_delta) for item in raw_items]
+
+    return {
+        "messages": messages,
+        "delta_token": next_token,
+        "has_more": has_more,
+    }

--- a/tests/test_calendar_delta.py
+++ b/tests/test_calendar_delta.py
@@ -1,0 +1,260 @@
+"""Tests for calendar delta tool."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from outlook_mcp.tools.calendar_delta import _format_event_delta, list_events_delta
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _raw_event(**overrides) -> dict:
+    """Build a raw Graph JSON event dict (the wire shape)."""
+    base = {
+        "id": "EVT_AAA",
+        "subject": "Standup",
+        "start": {"dateTime": "2026-05-22T15:00:00.0000000", "timeZone": "UTC"},
+        "end": {"dateTime": "2026-05-22T15:30:00.0000000", "timeZone": "UTC"},
+        "location": {"displayName": "Online"},
+        "isAllDay": False,
+        "organizer": {"emailAddress": {"address": "lead@test.com", "name": "Lead"}},
+        "responseStatus": {"response": "accepted"},
+        "isOnlineMeeting": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def _mock_graph_client():
+    client = MagicMock()
+    client.credential = MagicMock()
+    return client
+
+
+def _http_response(body: dict, status: int = 200):
+    r = MagicMock()
+    r.status_code = status
+    r.json = MagicMock(return_value=body)
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def _async_client_with(responses):
+    responses = list(responses)
+
+    async def fake_get(url, headers=None):
+        # Stash the call for later assertion
+        fake_get.last_call = {"url": url, "headers": headers}
+        return responses.pop(0)
+
+    fake_get.last_call = None
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=fake_get)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+
+    return (
+        patch(
+            "outlook_mcp.tools._delta.httpx.AsyncClient",
+            return_value=fake_client,
+        ),
+        fake_client,
+        fake_get,
+    )
+
+
+# ── Formatter ────────────────────────────────────────────────────────
+
+
+class TestFormatEventDelta:
+    def test_maps_basic_fields(self):
+        out = _format_event_delta(_raw_event())
+        assert out["id"] == "EVT_AAA"
+        assert out["subject"] == "Standup"
+        assert out["organizer"] == "Lead"
+        assert out["response_status"] == "accepted"
+        assert out["is_online"] is True
+        assert out["location"] == "Online"
+
+    def test_missing_subject_and_organizer(self):
+        out = _format_event_delta(
+            _raw_event(subject=None, organizer={"emailAddress": None})
+        )
+        assert out["subject"] == "(no subject)"
+        assert out["organizer"] == ""
+
+
+# ── First call ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_first_call_uses_prefer_header_and_window():
+    body = {
+        "value": [_raw_event(id="e1"), _raw_event(id="e2")],
+        "@odata.deltaLink": "https://graph/cal-delta",
+    }
+    patch_client, fake_client, fake_get = _async_client_with([_http_response(body)])
+    with patch_client:
+        result = await list_events_delta(
+            _mock_graph_client(),
+            start="2026-05-21T00:00:00Z",
+            end="2026-05-28T00:00:00Z",
+            page_size=25,
+        )
+
+    assert len(result["events"]) == 2
+    assert result["delta_token"] == "https://graph/cal-delta"
+    assert result["has_more"] is False
+
+    # Prefer header should carry the maxpagesize
+    headers = fake_get.last_call["headers"]
+    assert headers.get("Prefer") == "odata.maxpagesize=25"
+
+    # URL has the window encoded but no $top
+    url = fake_get.last_call["url"]
+    assert "startDateTime=" in url
+    assert "endDateTime=" in url
+    assert "$top" not in url
+
+
+# ── Subsequent call with delta_token ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_subsequent_call_uses_delta_token_url_verbatim():
+    body = {
+        "value": [_raw_event(id="changed")],
+        "@odata.deltaLink": "https://graph/cal-delta-new",
+    }
+    prior = "https://graph/cal-delta-prior"
+    patch_client, fake_client, fake_get = _async_client_with([_http_response(body)])
+    with patch_client:
+        result = await list_events_delta(
+            _mock_graph_client(),
+            start=None,
+            end=None,
+            delta_token=prior,
+        )
+
+    assert fake_get.last_call["url"] == prior
+    assert result["delta_token"] == "https://graph/cal-delta-new"
+
+
+# ── Missing window on first call ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_missing_start_raises_value_error():
+    with pytest.raises(ValueError, match="start"):
+        await list_events_delta(_mock_graph_client(), start=None, end="2026-05-28T00:00:00Z")
+
+
+@pytest.mark.asyncio
+async def test_missing_end_raises_value_error():
+    with pytest.raises(ValueError, match="end"):
+        await list_events_delta(_mock_graph_client(), start="2026-05-21T00:00:00Z", end=None)
+
+
+# ── Safety cap ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cap_reached_returns_nextlink_and_has_more():
+    page = lambda i, link: {  # noqa: E731
+        "value": [_raw_event(id=f"e{i*50 + n}") for n in range(50)],
+        "@odata.nextLink": link,
+    }
+    responses = [
+        _http_response(page(0, "https://graph/p2")),
+        _http_response(page(1, "https://graph/p3")),
+        _http_response(page(2, "https://graph/p4")),
+        _http_response(page(3, "https://graph/p5")),
+    ]
+    patch_client, fake_client, _ = _async_client_with(responses)
+    with patch_client:
+        result = await list_events_delta(
+            _mock_graph_client(),
+            start="2026-05-21T00:00:00Z",
+            end="2026-05-28T00:00:00Z",
+            page_size=50,
+        )
+
+    assert len(result["events"]) == 200
+    assert result["has_more"] is True
+    assert result["delta_token"] == "https://graph/p5"
+
+
+# ── Final page reached ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_follows_nextlink_until_deltalink():
+    responses = [
+        _http_response({
+            "value": [_raw_event(id="e1")],
+            "@odata.nextLink": "https://graph/p2",
+        }),
+        _http_response({
+            "value": [_raw_event(id="e2")],
+            "@odata.deltaLink": "https://graph/cal-delta-final",
+        }),
+    ]
+    patch_client, fake_client, _ = _async_client_with(responses)
+    with patch_client:
+        result = await list_events_delta(
+            _mock_graph_client(),
+            start="2026-05-21T00:00:00Z",
+            end="2026-05-28T00:00:00Z",
+        )
+
+    assert len(result["events"]) == 2
+    assert result["delta_token"] == "https://graph/cal-delta-final"
+    assert result["has_more"] is False
+
+
+# ── Tombstones ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_removed_event_collapses_to_id_only():
+    body = {
+        "value": [
+            _raw_event(id="e1"),
+            {"id": "e2-deleted", "@removed": {"reason": "deleted"}},
+        ],
+        "@odata.deltaLink": "https://graph/cal-delta",
+    }
+    patch_client, _, _ = _async_client_with([_http_response(body)])
+    with patch_client:
+        result = await list_events_delta(
+            _mock_graph_client(),
+            start="2026-05-21T00:00:00Z",
+            end="2026-05-28T00:00:00Z",
+        )
+
+    tomb = result["events"][1]
+    assert tomb == {"id": "e2-deleted", "is_deleted": True}
+    assert set(tomb.keys()) == {"id", "is_deleted"}
+    assert result["events"][0]["is_deleted"] is False
+
+
+# ── No-changes case ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_changes_returns_empty_list_and_delta_token():
+    body = {"value": [], "@odata.deltaLink": "https://graph/cal-delta-same"}
+    patch_client, _, _ = _async_client_with([_http_response(body)])
+    with patch_client:
+        result = await list_events_delta(
+            _mock_graph_client(),
+            start=None,
+            end=None,
+            delta_token="https://graph/cal-delta-prior",
+        )
+
+    assert result["events"] == []
+    assert result["delta_token"] == "https://graph/cal-delta-same"
+    assert result["has_more"] is False

--- a/tests/test_contacts_delta.py
+++ b/tests/test_contacts_delta.py
@@ -1,0 +1,222 @@
+"""Tests for contacts delta tool."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from outlook_mcp.tools.contacts_delta import _format_contact_delta, list_contacts_delta
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _raw_contact(**overrides) -> dict:
+    base = {
+        "id": "CONT_AAA",
+        "displayName": "Alice Example",
+        "emailAddresses": [
+            {"address": "alice@example.com", "name": "Alice"},
+        ],
+        "mobilePhone": "555-1212",
+        "homePhones": [],
+        "businessPhones": [],
+        "companyName": "Example Inc",
+    }
+    base.update(overrides)
+    return base
+
+
+def _mock_graph_client():
+    client = MagicMock()
+    client.credential = MagicMock()
+    return client
+
+
+def _http_response(body: dict, status: int = 200):
+    r = MagicMock()
+    r.status_code = status
+    r.json = MagicMock(return_value=body)
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def _async_client_with(responses):
+    responses = list(responses)
+
+    async def fake_get(url, headers=None):
+        fake_get.last_call = {"url": url, "headers": headers}
+        return responses.pop(0)
+
+    fake_get.last_call = None
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=fake_get)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+
+    return (
+        patch(
+            "outlook_mcp.tools._delta.httpx.AsyncClient",
+            return_value=fake_client,
+        ),
+        fake_client,
+        fake_get,
+    )
+
+
+# ── Formatter ────────────────────────────────────────────────────────
+
+
+class TestFormatContactDelta:
+    def test_maps_basic_fields(self):
+        out = _format_contact_delta(_raw_contact())
+        assert out["id"] == "CONT_AAA"
+        assert out["display_name"] == "Alice Example"
+        assert out["email"] == "alice@example.com"
+        assert out["phone"] == "555-1212"
+        assert out["company"] == "Example Inc"
+
+    def test_prefers_mobile_then_home_then_business(self):
+        out = _format_contact_delta(
+            _raw_contact(mobilePhone="", homePhones=["111"], businessPhones=["222"])
+        )
+        assert out["phone"] == "111"
+        out2 = _format_contact_delta(
+            _raw_contact(mobilePhone="", homePhones=[], businessPhones=["222"])
+        )
+        assert out2["phone"] == "222"
+
+    def test_missing_emails(self):
+        out = _format_contact_delta(_raw_contact(emailAddresses=[]))
+        assert out["email"] == ""
+
+
+# ── First call: no params allowed ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_first_call_uses_prefer_header_and_no_query_params():
+    body = {
+        "value": [_raw_contact(id="c1"), _raw_contact(id="c2")],
+        "@odata.deltaLink": "https://graph/contacts-delta",
+    }
+    patch_client, _, fake_get = _async_client_with([_http_response(body)])
+    with patch_client:
+        result = await list_contacts_delta(_mock_graph_client(), page_size=25)
+
+    assert len(result["contacts"]) == 2
+    assert result["delta_token"] == "https://graph/contacts-delta"
+    assert result["has_more"] is False
+
+    # No query string on the contacts/delta URL
+    url = fake_get.last_call["url"]
+    assert "?" not in url, f"expected bare URL, got {url}"
+
+    # maxpagesize must be in Prefer
+    headers = fake_get.last_call["headers"]
+    assert headers.get("Prefer") == "odata.maxpagesize=25"
+
+
+# ── Subsequent call ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_subsequent_call_uses_delta_token_url_verbatim():
+    body = {
+        "value": [_raw_contact(id="changed")],
+        "@odata.deltaLink": "https://graph/contacts-delta-new",
+    }
+    prior = "https://graph/contacts-delta-prior"
+    patch_client, _, fake_get = _async_client_with([_http_response(body)])
+    with patch_client:
+        result = await list_contacts_delta(_mock_graph_client(), delta_token=prior)
+
+    assert fake_get.last_call["url"] == prior
+    assert result["delta_token"] == "https://graph/contacts-delta-new"
+
+
+# ── Safety cap ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cap_reached_returns_nextlink_and_has_more():
+    page = lambda i, link: {  # noqa: E731
+        "value": [_raw_contact(id=f"c{i*50 + n}") for n in range(50)],
+        "@odata.nextLink": link,
+    }
+    responses = [
+        _http_response(page(0, "https://graph/p2")),
+        _http_response(page(1, "https://graph/p3")),
+        _http_response(page(2, "https://graph/p4")),
+        _http_response(page(3, "https://graph/p5")),
+    ]
+    patch_client, _, _ = _async_client_with(responses)
+    with patch_client:
+        result = await list_contacts_delta(_mock_graph_client(), page_size=50)
+
+    assert len(result["contacts"]) == 200
+    assert result["has_more"] is True
+    assert result["delta_token"] == "https://graph/p5"
+
+
+# ── Final page ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_follows_nextlink_until_deltalink():
+    responses = [
+        _http_response({
+            "value": [_raw_contact(id="c1")],
+            "@odata.nextLink": "https://graph/p2",
+        }),
+        _http_response({
+            "value": [_raw_contact(id="c2")],
+            "@odata.deltaLink": "https://graph/contacts-delta-final",
+        }),
+    ]
+    patch_client, _, _ = _async_client_with(responses)
+    with patch_client:
+        result = await list_contacts_delta(_mock_graph_client())
+
+    assert len(result["contacts"]) == 2
+    assert result["delta_token"] == "https://graph/contacts-delta-final"
+    assert result["has_more"] is False
+
+
+# ── Tombstones ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_removed_contact_collapses_to_id_only():
+    body = {
+        "value": [
+            _raw_contact(id="c1"),
+            {"id": "c2-deleted", "@removed": {"reason": "deleted"}},
+        ],
+        "@odata.deltaLink": "https://graph/contacts-delta",
+    }
+    patch_client, _, _ = _async_client_with([_http_response(body)])
+    with patch_client:
+        result = await list_contacts_delta(_mock_graph_client())
+
+    tomb = result["contacts"][1]
+    assert tomb == {"id": "c2-deleted", "is_deleted": True}
+    assert set(tomb.keys()) == {"id", "is_deleted"}
+    assert result["contacts"][0]["is_deleted"] is False
+
+
+# ── No-changes case ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_changes_returns_empty_list_and_delta_token():
+    body = {"value": [], "@odata.deltaLink": "https://graph/contacts-delta-same"}
+    patch_client, _, _ = _async_client_with([_http_response(body)])
+    with patch_client:
+        result = await list_contacts_delta(
+            _mock_graph_client(),
+            delta_token="https://graph/contacts-delta-prior",
+        )
+
+    assert result["contacts"] == []
+    assert result["delta_token"] == "https://graph/contacts-delta-same"
+    assert result["has_more"] is False

--- a/tests/test_mail_delta.py
+++ b/tests/test_mail_delta.py
@@ -1,0 +1,261 @@
+"""Tests for mail delta tool."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from outlook_mcp.tools.mail_delta import _format_message_delta, list_inbox_delta
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _raw_message(**overrides) -> dict:
+    """Build a raw Graph JSON message dict (the wire shape)."""
+    base = {
+        "id": "AAMkAG123=",
+        "subject": "Test Subject",
+        "from": {"emailAddress": {"address": "sender@test.com", "name": "Sender"}},
+        "receivedDateTime": "2026-05-21T10:00:00Z",
+        "isRead": False,
+        "importance": "normal",
+        "bodyPreview": "Preview text",
+        "hasAttachments": False,
+        "categories": [],
+        "flag": {"flagStatus": "notFlagged"},
+        "conversationId": "conv123",
+        "inferenceClassification": "focused",
+    }
+    base.update(overrides)
+    return base
+
+
+def _mock_graph_client():
+    """Build a minimal graph_client that delta tools accept.
+
+    Delta tools need ``.sdk_client`` (used by ``resolve_folder_id`` on
+    the first call only) and ``.credential`` (used to mint raw bearer
+    tokens for the httpx call).
+    """
+    client = MagicMock()
+    client.credential = MagicMock()
+    return client
+
+
+def _patch_resolve(folder_id: str = "INBOX_ID"):
+    return patch(
+        "outlook_mcp.tools.mail_delta.resolve_folder_id",
+        new=AsyncMock(return_value=folder_id),
+    )
+
+
+def _http_response(body: dict, status: int = 200):
+    """Mock an httpx.Response with .json() and .raise_for_status()."""
+    r = MagicMock()
+    r.status_code = status
+    r.json = MagicMock(return_value=body)
+    r.raise_for_status = MagicMock()
+    return r
+
+
+def _async_client_with(responses):
+    """Patch httpx.AsyncClient so its .get() walks a queue of responses."""
+    responses = list(responses)
+
+    async def fake_get(url, headers=None):
+        return responses.pop(0)
+
+    fake_client = MagicMock()
+    fake_client.get = AsyncMock(side_effect=fake_get)
+    fake_client.__aenter__ = AsyncMock(return_value=fake_client)
+    fake_client.__aexit__ = AsyncMock(return_value=False)
+
+    return patch(
+        "outlook_mcp.tools._delta.httpx.AsyncClient",
+        return_value=fake_client,
+    ), fake_client
+
+
+# ── Formatter ────────────────────────────────────────────────────────
+
+
+class TestFormatMessageDelta:
+    def test_maps_basic_fields(self):
+        out = _format_message_delta(_raw_message())
+        assert out["id"] == "AAMkAG123="
+        assert out["subject"] == "Test Subject"
+        assert out["from_email"] == "sender@test.com"
+        assert out["from_name"] == "Sender"
+        assert out["is_read"] is False
+        assert out["importance"] == "normal"
+        assert out["flag"] == "notFlagged"
+        assert out["conversation_id"] == "conv123"
+        assert out["classification"] == "focused"
+
+    def test_missing_from_node(self):
+        out = _format_message_delta(_raw_message(**{"from": None}))
+        assert out["from_email"] == ""
+        assert out["from_name"] == ""
+
+    def test_missing_subject(self):
+        out = _format_message_delta(_raw_message(subject=None))
+        assert out["subject"] == "(no subject)"
+
+
+# ── First call ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_first_call_returns_messages_and_delta_token():
+    body = {
+        "value": [_raw_message(id="m1"), _raw_message(id="m2")],
+        "@odata.deltaLink": "https://graph.microsoft.com/v1.0/me/mailFolders('INBOX')/messages/delta?$deltatoken=abc",
+    }
+    patch_client, _ = _async_client_with([_http_response(body)])
+    with _patch_resolve(), patch_client:
+        result = await list_inbox_delta(_mock_graph_client(), folder="inbox", page_size=50)
+
+    assert len(result["messages"]) == 2
+    assert result["messages"][0]["id"] == "m1"
+    assert all(m["is_deleted"] is False for m in result["messages"])
+    assert result["delta_token"] == body["@odata.deltaLink"]
+    assert result["has_more"] is False
+
+
+# ── Subsequent call with delta_token ─────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_subsequent_call_uses_delta_token_as_url():
+    prior_token = "https://graph.microsoft.com/v1.0/me/mailFolders('INBOX')/messages/delta?$deltatoken=abc"
+    new_delta = "https://graph.microsoft.com/v1.0/me/mailFolders('INBOX')/messages/delta?$deltatoken=def"
+    body = {
+        "value": [_raw_message(id="changed1", subject="Updated")],
+        "@odata.deltaLink": new_delta,
+    }
+    patch_client, fake_client = _async_client_with([_http_response(body)])
+    with _patch_resolve(), patch_client:
+        # resolve_folder_id should NOT be called on a delta-token call
+        result = await list_inbox_delta(
+            _mock_graph_client(), folder="inbox", delta_token=prior_token
+        )
+
+    # The delta_token URL was used verbatim
+    called_url = fake_client.get.call_args.args[0]
+    assert called_url == prior_token
+
+    assert len(result["messages"]) == 1
+    assert result["messages"][0]["subject"] == "Updated"
+    assert result["delta_token"] == new_delta
+    assert result["has_more"] is False
+
+
+# ── Safety cap ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cap_reached_returns_nextlink_and_has_more():
+    """200 messages with page_size=50 → cap=200 hit exactly; nextLink returned."""
+    page = lambda i, link: {  # noqa: E731
+        "value": [_raw_message(id=f"m{i*50 + n}") for n in range(50)],
+        "@odata.nextLink": link,
+    }
+    # Cap is page_size * 4 = 200; deliver 4 nextLink pages of 50 each, the
+    # last one also a nextLink so the cap triggers.
+    responses = [
+        _http_response(page(0, "https://graph/page2")),
+        _http_response(page(1, "https://graph/page3")),
+        _http_response(page(2, "https://graph/page4")),
+        _http_response(page(3, "https://graph/page5")),
+    ]
+    patch_client, fake_client = _async_client_with(responses)
+    with _patch_resolve(), patch_client:
+        result = await list_inbox_delta(_mock_graph_client(), folder="inbox", page_size=50)
+
+    assert len(result["messages"]) == 200
+    assert result["has_more"] is True
+    assert result["delta_token"] == "https://graph/page5"
+    # 4 HTTP calls total — the 4th came back with a nextLink that we hand
+    # to the caller instead of following.
+    assert fake_client.get.await_count == 4
+
+
+# ── Final page reached after several pages ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_follows_nextlink_until_deltalink():
+    """Two nextLink pages then a deltaLink — should follow both, return deltaLink."""
+    responses = [
+        _http_response({
+            "value": [_raw_message(id="m1")],
+            "@odata.nextLink": "https://graph/p2",
+        }),
+        _http_response({
+            "value": [_raw_message(id="m2")],
+            "@odata.deltaLink": "https://graph/delta-final",
+        }),
+    ]
+    patch_client, fake_client = _async_client_with(responses)
+    with _patch_resolve(), patch_client:
+        result = await list_inbox_delta(_mock_graph_client(), folder="inbox", page_size=50)
+
+    assert len(result["messages"]) == 2
+    assert result["delta_token"] == "https://graph/delta-final"
+    assert result["has_more"] is False
+    assert fake_client.get.await_count == 2
+
+
+# ── Tombstones (@removed) ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_removed_item_collapses_to_id_only():
+    body = {
+        "value": [
+            _raw_message(id="m1"),
+            {"id": "m2-deleted", "@removed": {"reason": "deleted"}},
+        ],
+        "@odata.deltaLink": "https://graph/delta",
+    }
+    patch_client, _ = _async_client_with([_http_response(body)])
+    with _patch_resolve(), patch_client:
+        result = await list_inbox_delta(_mock_graph_client())
+
+    assert result["messages"][0] == {**result["messages"][0], "is_deleted": False}
+    tomb = result["messages"][1]
+    assert tomb == {"id": "m2-deleted", "is_deleted": True}
+    # No other fields on a tombstone — agents shouldn't see stale data.
+    assert set(tomb.keys()) == {"id", "is_deleted"}
+
+
+# ── No changes (empty value, only deltaLink) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_changes_returns_empty_list_and_delta_token():
+    body = {
+        "value": [],
+        "@odata.deltaLink": "https://graph/delta-same",
+    }
+    patch_client, _ = _async_client_with([_http_response(body)])
+    with _patch_resolve(), patch_client:
+        result = await list_inbox_delta(
+            _mock_graph_client(), delta_token="https://graph/prior-delta"
+        )
+
+    assert result["messages"] == []
+    assert result["delta_token"] == "https://graph/delta-same"
+    assert result["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_no_links_at_all_returns_none_token():
+    """If Graph returns neither nextLink nor deltaLink, hand back None."""
+    body = {"value": []}
+    patch_client, _ = _async_client_with([_http_response(body)])
+    with _patch_resolve(), patch_client:
+        result = await list_inbox_delta(_mock_graph_client())
+
+    assert result["messages"] == []
+    assert result["delta_token"] is None
+    assert result["has_more"] is False

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,11 +10,12 @@ from outlook_mcp.server import _wrap_tool_errors, mcp
 EXPECTED_TOOLS = [
     # Auth (3)
     "outlook_auth_status",
-    # Mail read (4)
+    # Mail read (5)
     "outlook_list_inbox",
     "outlook_read_message",
     "outlook_search_mail",
     "outlook_list_folders",
+    "outlook_list_inbox_delta",
     # Mail write (3)
     "outlook_send_message",
     "outlook_reply",
@@ -86,9 +87,9 @@ EXPECTED_TOOLS = [
 
 
 def test_tool_count():
-    """All 57 tools are registered (auth is CLI-only now)."""
+    """All 58 tools are registered (auth is CLI-only now)."""
     registered = set(mcp._tool_manager._tools.keys())
-    assert len(registered) == 57
+    assert len(registered) == 58
 
 
 def test_all_tools_registered():

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -30,22 +30,24 @@ EXPECTED_TOOLS = [
     "outlook_list_inbox_overrides",
     "outlook_set_inbox_override",
     "outlook_delete_inbox_override",
-    # Calendar read (2)
+    # Calendar read (3)
     "outlook_list_events",
     "outlook_get_event",
+    "outlook_list_events_delta",
     # Calendar write (4)
     "outlook_create_event",
     "outlook_update_event",
     "outlook_delete_event",
     "outlook_rsvp",
     # ── Tier 2 ──────────────────────────────────────────
-    # Contacts (6)
+    # Contacts (7)
     "outlook_list_contacts",
     "outlook_search_contacts",
     "outlook_get_contact",
     "outlook_create_contact",
     "outlook_update_contact",
     "outlook_delete_contact",
+    "outlook_list_contacts_delta",
     # To Do (6)
     "outlook_list_task_lists",
     "outlook_list_tasks",
@@ -87,9 +89,9 @@ EXPECTED_TOOLS = [
 
 
 def test_tool_count():
-    """All 58 tools are registered (auth is CLI-only now)."""
+    """All 60 tools are registered (auth is CLI-only now)."""
     registered = set(mcp._tool_manager._tools.keys())
-    assert len(registered) == 58
+    assert len(registered) == 60
 
 
 def test_all_tools_registered():

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "outlook-graph-mcp"
-version = "1.8.0"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },


### PR DESCRIPTION
> **Stacked on #17 (v1.8.0).** Review #17 first. Once #17 merges, this PR's base auto-rebases to \`main\`.

## Why

Three new tools that wrap Microsoft Graph's `/delta` endpoints. Verified working on personal Microsoft accounts via direct curl + the preflight script (13/13 OK).

For agents on recurring jobs (Neo's morning brief, hourly inbox scans), this is the single biggest token-cost reduction available: the first call snapshots everything, every subsequent call returns only changed items. Typical follow-up call: 0–3 messages instead of 25.

## What

### New tools

- **`outlook_list_inbox_delta(folder="inbox", page_size=50, delta_token=None)`** → `{messages, delta_token, has_more}`
- **`outlook_list_events_delta(start, end, page_size=50, delta_token=None)`** → `{events, delta_token, has_more}`  (start+end required on first call only)
- **`outlook_list_contacts_delta(page_size=50, delta_token=None)`** → `{contacts, delta_token, has_more}`

All three: stateless (caller persists the opaque `delta_token` and passes it back), auto-paginate internally up to a safety cap (`page_size * 4`), set `has_more=True` if cap reached so the caller knows to drain.

### Deleted-item semantics

Graph returns `@removed` annotations for items deleted since last sync. Tools surface these as `{id, is_deleted: true}` (no other fields — tombstones don't carry data). Documented in every tool's docstring.

### Implementation choices

- **Shared `tools/_delta.py` helper** (private module, underscore-prefixed) handles the common pagination/cap/tombstone logic so each per-resource module stays small.
- **Raw httpx** instead of the msgraph SDK delta builders. The SDK's typed query-params dataclass silently drops `$deltatoken` on round-trip and discards `@removed` annotations — both deal-breakers. Raw httpx matches the pattern already in `scripts/preflight.py`.
- **One-line addition to `graph.py`** to retain `self.credential` so delta tools can mint bearer tokens for direct calls.

### Preflight additions

3 new rows in `scripts/preflight.py::ENDPOINTS`, all verified live:
- `me/mailFolders/inbox/messages/delta`
- `me/calendarView/delta?startDateTime=...&endDateTime=...`
- `me/contacts/delta`

## Test plan

- [x] `uv run pytest --tb=no -q` → **501 passed**, 6 skipped, 0 unexpected failures (up from 472; +29 new tests).
- [x] `uv run ruff check src/ tests/ scripts/` → clean.
- [x] `uv run python scripts/preflight.py` → **13/13 endpoints OK** including the 3 new delta endpoints.
- [x] AST check: all 3 new `@mcp.tool()` definitions have `_wrap_tool_errors` decorator stacked (mandatory per v1.8.0).
- [x] Commits are bisectable: tool-count assertion + EXPECTED_TOOLS bumped incrementally so every commit's HEAD passes tests.
- [ ] Manual smoke after merge: call inbox_delta twice on a real mailbox, confirm second call returns far fewer items + a stable delta_token.

## Surprises worth knowing (for the reviewer)

1. **`delta_token: None` in the response is NOT "session over."** Graph occasionally returns `value: []` with neither `@odata.nextLink` nor `@odata.deltaLink`. The helper returns `delta_token=None` in that case; agents should **reuse their previously-stored token** rather than discard it. Documented in `_delta.py` and tool docstrings.
2. **Tombstones (`is_deleted: true`) carry only `id`.** No subject/from/etc. Agents must not assume those fields exist on deleted items.
3. **`has_more=True` returns a nextLink, not a deltaLink.** Replay it immediately (or soon) to drain the round; the actual deltaLink only appears on the final page of the current sync cycle.
4. **Calendar `start`+`end` required only on first call.** Follow-up calls encode the window in the cursor URL — pass `start=None, end=None`.
5. **Folder names baked into the cursor.** `outlook_list_inbox_delta(folder="Junk Email")` resolves the display name once on the first call and bakes the Graph folder ID into all subsequent delta URLs. Folder rename mid-session doesn't break the tracking.

## Docs

- `CHANGELOG.md` — 1.9.0 entry with the agent-cost story + cursor semantics + deleted-item note.
- `README.md` + `SKILL.md` — tool count 57 → 60; new tools in the relevant tables/sections.
- `ROADMAP.md` — 1.9.0 added to Done; "Delta queries" removed from Near-term.
- `CLAUDE.md` — three new tool-module entries.
- `pyproject.toml` + `server.json` — version 1.9.0; description `(60 tools)`.

Generated with [Claude Code](https://claude.com/claude-code)