### PR TITLE
Add uncategorized_only filter to list_inbox

### DIFF
--- a/src/outlook_mcp/server.py
+++ b/src/outlook_mcp/server.py
@@ -154,6 +154,7 @@ async def outlook_list_inbox(
     skip: int = 0,
     cursor: str | None = None,
     classification: str | None = None,
+    uncategorized_only: bool = False,
     concise: bool = False,
 ) -> dict:
     """List messages in one folder with structured filters (read, sender, date, Focused class).
@@ -165,6 +166,7 @@ async def outlook_list_inbox(
     Example: outlook_list_inbox(folder="Junk Email", unread_only=True, count=5)
     `folder` accepts display names, well-known names ("inbox", "junkemail"), or Graph IDs — prefer
     names. Pass concise=True to drop large fields (preview, categories) — ~10x fewer tokens.
+    Pass uncategorized_only=True to return only messages with no categories assigned.
     """
     client = _get_graph_client(ctx)
     return await mail_read.list_inbox(
@@ -178,6 +180,7 @@ async def outlook_list_inbox(
         skip,
         cursor=cursor,
         classification=classification,
+        uncategorized_only=uncategorized_only,
         concise=concise,
     )
 

--- a/src/outlook_mcp/server.py
+++ b/src/outlook_mcp/server.py
@@ -154,10 +154,10 @@ async def outlook_list_inbox(
     skip: int = 0,
     cursor: str | None = None,
     classification: str | None = None,
-    uncategorized_only: bool = False,
     concise: bool = False,
+    uncategorized_only: bool = False,
 ) -> dict:
-    """List messages in one folder with structured filters (read, sender, date, Focused class).
+    """List messages in one folder with structured filters (read, sender, date, category, Focused).
 
     Use this for folder-scoped browsing; use outlook_search_mail for KQL full-text search across
     all folders. For polling/recurring agents use outlook_list_inbox_delta (typically 10x cheaper
@@ -180,8 +180,8 @@ async def outlook_list_inbox(
         skip,
         cursor=cursor,
         classification=classification,
-        uncategorized_only=uncategorized_only,
         concise=concise,
+        uncategorized_only=uncategorized_only,
     )
 
 

--- a/src/outlook_mcp/tools/mail_read.py
+++ b/src/outlook_mcp/tools/mail_read.py
@@ -115,8 +115,8 @@ async def list_inbox(
     skip: int = 0,
     cursor: str | None = None,
     classification: str | None = None,
-    uncategorized_only: bool = False,
     concise: bool = False,
+    uncategorized_only: bool = False,
 ) -> dict:
     """List messages in a folder.
 

--- a/src/outlook_mcp/tools/mail_read.py
+++ b/src/outlook_mcp/tools/mail_read.py
@@ -115,12 +115,16 @@ async def list_inbox(
     skip: int = 0,
     cursor: str | None = None,
     classification: str | None = None,
+    uncategorized_only: bool = False,
     concise: bool = False,
 ) -> dict:
     """List messages in a folder.
 
     classification: filter by Focused Inbox classification — "focused" or "other".
     None means no filter (both).
+
+    uncategorized_only: when True, filter to only messages with no categories assigned
+    (uses OData ``not categories/any()``). Default False.
 
     concise: when True, drop ``preview`` and ``categories`` from each message
     (smaller payload for triage scans). Default False preserves the existing shape.
@@ -163,6 +167,8 @@ async def list_inbox(
                 f"Must be one of: {sorted(VALID_CLASSIFICATIONS)}"
             )
         other_filters.append(f"inferenceClassification eq '{classification}'")
+    if uncategorized_only:
+        other_filters.append("not categories/any()")
 
     # $orderby is unconditionally `receivedDateTime desc`, so any non-date clause
     # needs a leading receivedDateTime clause. A caller-supplied after/before

--- a/tests/test_mail_read.py
+++ b/tests/test_mail_read.py
@@ -195,6 +195,53 @@ class TestListInbox:
         assert "inferenceClassification eq 'focused'" in qp.filter
         assert " and " in qp.filter
 
+    @pytest.mark.asyncio
+    async def test_list_inbox_uncategorized_only_adds_odata(self):
+        """uncategorized_only=True adds not categories/any() filter to query."""
+        mock_client = _make_folder_mock([])
+        await list_inbox(mock_client, uncategorized_only=True)
+
+        call_kwargs = (
+            mock_client.me.mail_folders.by_mail_folder_id.return_value
+            .messages.get.call_args
+        )
+        qp = call_kwargs.kwargs["request_configuration"].query_parameters
+        assert qp.filter is not None
+        assert "not categories/any()" in qp.filter
+
+    @pytest.mark.asyncio
+    async def test_list_inbox_uncategorized_only_absent_by_default(self):
+        """uncategorized_only=False (default) adds no $filter at all."""
+        mock_client = _make_folder_mock([])
+        await list_inbox(mock_client)
+
+        call_kwargs = (
+            mock_client.me.mail_folders.by_mail_folder_id.return_value
+            .messages.get.call_args
+        )
+        qp = call_kwargs.kwargs["request_configuration"].query_parameters
+        assert qp.filter is None
+
+    @pytest.mark.asyncio
+    async def test_list_inbox_uncategorized_only_combines_with_other_filters(self):
+        """uncategorized_only joins with unread_only and classification via 'and'."""
+        mock_client = _make_folder_mock([])
+        await list_inbox(
+            mock_client,
+            unread_only=True,
+            classification="focused",
+            uncategorized_only=True,
+        )
+
+        call_kwargs = (
+            mock_client.me.mail_folders.by_mail_folder_id.return_value
+            .messages.get.call_args
+        )
+        qp = call_kwargs.kwargs["request_configuration"].query_parameters
+        assert "isRead eq false" in qp.filter
+        assert "inferenceClassification eq 'focused'" in qp.filter
+        assert "not categories/any()" in qp.filter
+
 
 class TestListInboxFilterOrdering:
     """Graph 400s with InefficientFilter unless a receivedDateTime clause leads


### PR DESCRIPTION
## Why

Makes it easier for agents working on categorizing email to run a simple query to get the next batch of emails for processing. Previously there was no way to filter for messages with no categories assigned.

## What

- `outlook_list_inbox` (src/outlook_mcp/server.py): new optional `uncategorized_only: bool = False` parameter, passed through to the tool.
- `list_inbox` (src/outlook_mcp/tools/mail_read.py): when `uncategorized_only=True`, appends `not categories/any()` to the OData `$filter`, joined with any other active filters (unread_only, from_address, date range, classification) via `and`.
- Default is `False` — behavior is unchanged when the flag is omitted.
- New tests in tests/test_mail_read.py.

## Test plan

- [x] `uv run pytest tests/test_mail_read.py -k uncategorized -v` → 3/3 pass
  - uncategorized_only=True adds `not categories/any()` to the filter
  - default (flag omitted) adds no `$filter` at all
  - combined with unread_only + classification, all three clauses join via `and`
- [x] `uv run pytest tests/test_mail_read.py -q` → 27 pass
- [x] Full suite `uv run pytest --tb=no -q` → 548 pass, 13 pre-existing env failures (unrelated: calendar date + Windows symlink/permissions in test_config), 0 regressions from this change
