### PR TITLE
fix(graph): repair three live query-shape bugs invisible to the mock suite

### DIFF
--- a/src/outlook_mcp/server.py
+++ b/src/outlook_mcp/server.py
@@ -254,6 +254,8 @@ async def outlook_search_mail(
 
     Example: outlook_search_mail(query="from:sarah@acme.com received>=2026-01-01", count=10)
     `query` is Microsoft KQL (from:, subject:, received>=, hasattachment:true, AND/OR/NOT).
+    Operators must be UPPERCASE — lowercase `and` is matched as a literal term. Two terms
+    with no operator between them broaden the search; use AND explicitly to narrow.
     Pass concise=True to drop large fields (preview, categories) — ~10x fewer tokens.
     """
     client = _get_graph_client(ctx)

--- a/src/outlook_mcp/tools/mail_read.py
+++ b/src/outlook_mcp/tools/mail_read.py
@@ -93,6 +93,16 @@ def _format_message_summary(msg: Any) -> dict:
 
 VALID_CLASSIFICATIONS = {"focused", "other"}
 
+# Graph rejects `$orderby=receivedDateTime` combined with a `$filter` on any other
+# property (400 InefficientFilter) unless a receivedDateTime clause comes FIRST in
+# the filter. Presence alone is not enough — clause order is load-bearing, verified
+# live: the same clauses with receivedDateTime second still 400. When the caller
+# supplies no after/before we prepend this permissive floor to satisfy the index.
+# 1900-01-01 is a readable floor that predates any real mail item; mailbox $count is
+# identical with and without it. See https://devblogs.microsoft.com/microsoft365dev/
+# update-to-filtering-and-sorting-rest-api/
+RECEIVED_FLOOR = "1900-01-01T00:00:00Z"
+
 
 async def list_inbox(
     graph_client: Any,
@@ -129,28 +139,38 @@ async def list_inbox(
     if not cursor and skip:
         query_params["$skip"] = skip
 
-    # Build filter with validated inputs
-    filters = []
+    # Build filter with validated inputs. Clauses are validated in signature order
+    # (so validation errors keep their existing precedence) but emitted with the
+    # receivedDateTime clauses first — see RECEIVED_FLOOR.
+    date_filters: list[str] = []
+    other_filters: list[str] = []
     if unread_only:
-        filters.append("isRead eq false")
+        other_filters.append("isRead eq false")
     if from_address:
         validate_email(from_address)
         safe_from = from_address.replace("'", "''")
-        filters.append(f"from/emailAddress/address eq '{safe_from}'")
+        other_filters.append(f"from/emailAddress/address eq '{safe_from}'")
     if after:
         safe_after = validate_datetime(after)
-        filters.append(f"receivedDateTime ge {safe_after}")
+        date_filters.append(f"receivedDateTime ge {safe_after}")
     if before:
         safe_before = validate_datetime(before)
-        filters.append(f"receivedDateTime le {safe_before}")
+        date_filters.append(f"receivedDateTime le {safe_before}")
     if classification is not None:
         if classification not in VALID_CLASSIFICATIONS:
             raise ValueError(
                 f"Invalid classification '{classification}'. "
                 f"Must be one of: {sorted(VALID_CLASSIFICATIONS)}"
             )
-        filters.append(f"inferenceClassification eq '{classification}'")
+        other_filters.append(f"inferenceClassification eq '{classification}'")
 
+    # $orderby is unconditionally `receivedDateTime desc`, so any non-date clause
+    # needs a leading receivedDateTime clause. A caller-supplied after/before
+    # already satisfies that — don't double-add.
+    if other_filters and not date_filters:
+        date_filters.append(f"receivedDateTime ge {RECEIVED_FLOOR}")
+
+    filters = date_filters + other_filters
     if filters:
         query_params["$filter"] = " and ".join(filters)
 

--- a/src/outlook_mcp/tools/mail_thread.py
+++ b/src/outlook_mcp/tools/mail_thread.py
@@ -9,7 +9,7 @@ from outlook_mcp.config import Config
 from outlook_mcp.folder_resolver import resolve_folder_id
 from outlook_mcp.pagination import build_request_config
 from outlook_mcp.permissions import CATEGORY_MAIL_TRIAGE, check_permission
-from outlook_mcp.tools.mail_read import _format_message_summary
+from outlook_mcp.tools.mail_read import RECEIVED_FLOOR, _format_message_summary
 from outlook_mcp.validation import sanitize_output, validate_graph_id
 
 
@@ -66,7 +66,12 @@ async def list_thread(
     count = _clamp(count, 1, 100)
 
     query_params = {
-        "$filter": f"conversationId eq '{conversation_id}'",
+        # The receivedDateTime floor must precede conversationId or Graph rejects
+        # the receivedDateTime $orderby with 400 InefficientFilter — see
+        # RECEIVED_FLOOR. Without it this tool 400s on every call.
+        "$filter": (
+            f"receivedDateTime ge {RECEIVED_FLOOR} and conversationId eq '{conversation_id}'"
+        ),
         "$orderby": "receivedDateTime asc",
         "$top": count,
         "$select": (

--- a/src/outlook_mcp/validation.py
+++ b/src/outlook_mcp/validation.py
@@ -12,8 +12,21 @@ _EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$")
 # Phone pattern
 _PHONE_RE = re.compile(r"^[0-9 ()+.\-]{1,30}$")
 
-# KQL dangerous characters to strip
-_KQL_DANGEROUS = re.compile(r'[":()&|!*\\]')
+# KQL characters to strip. The value is embedded as `$search="<value>"`, so the
+# only real boundary is the string literal itself. Verified live against Graph:
+#   "  MUST strip — an embedded quote makes Graph SILENTLY DISCARD $search and
+#      return the whole mailbox (200, no error). This is the actual vector.
+#   \  MUST strip — a real escape metachar. `\s` is a 400 (unrecognized escape)
+#      and a trailing `\` escapes our closing quote (400, unterminated literal).
+#   *  stripped — buys nothing (Graph already prefix-matches: `subject:Amaz` and
+#      `subject:Amaz*` both return 50), and a bare `*` would become a silent
+#      whole-mailbox read where it is currently a loud 400.
+#   &|! stripped — not operators. Graph's operators are the uppercase words
+#      AND/OR/NOT; the symbol forms silently zero out an otherwise-matching query.
+# `:` `(` `)` are deliberately NOT stripped — they are the property-restriction and
+# grouping syntax the tools document, and stripping `:` silently turned every
+# documented query into a zero-result free-text phrase.
+_KQL_DANGEROUS = re.compile(r'["&|!*\\]')
 
 # Control characters (C0 + C1 + DEL), excluding \n and \t
 _CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
@@ -83,8 +96,20 @@ def validate_datetime(value: str) -> str:
 
 
 def sanitize_kql(query: str) -> str:
-    """Sanitize a KQL search query to prevent injection."""
+    """Sanitize a KQL search query to prevent injection.
+
+    The value is embedded as ``$search="<value>"``; the surrounding quotes are
+    load-bearing (an unquoted ``:`` is a Graph 400), so the strip only has to
+    protect the string-literal boundary. See ``_KQL_DANGEROUS``.
+    """
     sanitized = _KQL_DANGEROUS.sub("", query)
+    if not sanitized.strip():
+        # Would send $search="" — Graph answers with an opaque BadRequest.
+        raise ValueError(
+            f"Search query is empty after sanitization: {query[:50]!r}. "
+            'Quotes, backslashes and the characters & | ! * are removed; '
+            "use KQL syntax like subject:budget or from:sarah@acme.com."
+        )
     return f'"{sanitized}"'
 
 

--- a/tests/test_contacts.py
+++ b/tests/test_contacts.py
@@ -154,11 +154,12 @@ class TestSearchContacts:
         result = await search_contacts(mock_client, query='John" OR (hack)')
         assert result["count"] == 0
 
-        # Verify the search param was sanitized (quotes/parens stripped)
+        # Verify the search param was sanitized. Only the string-literal
+        # boundary chars are stripped; `(` is legitimate KQL grouping.
         call_kwargs = mock_client.me.contacts.get.call_args
         qp = call_kwargs.kwargs["request_configuration"].query_parameters
         assert '"' not in qp.search.strip('"')
-        assert "(" not in qp.search.strip('"')
+        assert "\\" not in qp.search
 
     async def test_search_returns_contacts(self):
         """search_contacts returns matching contacts."""

--- a/tests/test_mail_read.py
+++ b/tests/test_mail_read.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from outlook_mcp.tools.mail_read import (
+    RECEIVED_FLOOR,
     _format_message_summary,
     list_folders,
     list_inbox,
@@ -193,6 +194,88 @@ class TestListInbox:
         assert "isRead eq false" in qp.filter
         assert "inferenceClassification eq 'focused'" in qp.filter
         assert " and " in qp.filter
+
+
+class TestListInboxFilterOrdering:
+    """Graph 400s with InefficientFilter unless a receivedDateTime clause leads
+    the $filter, because $orderby is unconditionally receivedDateTime desc.
+    Clause ORDER is load-bearing, so these assert position, not just presence.
+    """
+
+    @staticmethod
+    def _filter_for(mock_client):
+        call_kwargs = (
+            mock_client.me.mail_folders.by_mail_folder_id.return_value
+            .messages.get.call_args
+        )
+        return call_kwargs.kwargs["request_configuration"].query_parameters.filter
+
+    @pytest.mark.asyncio
+    async def test_no_filter_means_no_floor(self):
+        """An unfiltered call needs no floor — $orderby alone is fine."""
+        mock_client = _make_folder_mock([])
+        await list_inbox(mock_client)
+        assert self._filter_for(mock_client) is None
+
+    @pytest.mark.asyncio
+    async def test_floor_prepended_for_non_date_filter(self):
+        """from_address alone returned 400 in 1.12.0 — it needs the floor."""
+        mock_client = _make_folder_mock([])
+        await list_inbox(mock_client, from_address="sarah@acme.com")
+        assert self._filter_for(mock_client) == (
+            f"receivedDateTime ge {RECEIVED_FLOOR} "
+            "and from/emailAddress/address eq 'sarah@acme.com'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_classification_leads_with_floor(self):
+        """classification alone also returned 400 in 1.12.0."""
+        mock_client = _make_folder_mock([])
+        await list_inbox(mock_client, classification="focused")
+        assert self._filter_for(mock_client).startswith(
+            f"receivedDateTime ge {RECEIVED_FLOOR} and"
+        )
+
+    @pytest.mark.asyncio
+    async def test_caller_date_filter_is_not_double_floored(self):
+        """A caller-supplied `after` already satisfies the index — don't add."""
+        mock_client = _make_folder_mock([])
+        await list_inbox(mock_client, after="2026-01-01", from_address="s@acme.com")
+        filter_str = self._filter_for(mock_client)
+        assert RECEIVED_FLOOR not in filter_str
+        assert filter_str.startswith("receivedDateTime ge 2026-01-01")
+
+    @pytest.mark.asyncio
+    async def test_before_only_leads_and_is_not_floored(self):
+        """A `before`-only filter leads with `le` and is accepted by Graph."""
+        mock_client = _make_folder_mock([])
+        await list_inbox(mock_client, before="2026-06-01", unread_only=True)
+        filter_str = self._filter_for(mock_client)
+        assert RECEIVED_FLOOR not in filter_str
+        assert filter_str.startswith("receivedDateTime le 2026-06-01")
+
+    @pytest.mark.asyncio
+    async def test_date_clauses_always_precede_other_clauses(self):
+        """The invariant: no non-date clause may appear before a date clause."""
+        mock_client = _make_folder_mock([])
+        await list_inbox(
+            mock_client,
+            unread_only=True,
+            from_address="s@acme.com",
+            classification="focused",
+            after="2026-01-01",
+            before="2026-06-01",
+        )
+        clauses = self._filter_for(mock_client).split(" and ")
+        is_date = [c.startswith("receivedDateTime") for c in clauses]
+        assert is_date == sorted(is_date, reverse=True), clauses
+
+    @pytest.mark.asyncio
+    async def test_validation_error_precedence_unchanged(self):
+        """Reordering emitted clauses must not reorder validation errors."""
+        mock_client = _make_folder_mock([])
+        with pytest.raises(ValueError, match="email"):
+            await list_inbox(mock_client, from_address="bogus", after="not-a-date")
 
 
 class TestReadMessage:

--- a/tests/test_mail_thread.py
+++ b/tests/test_mail_thread.py
@@ -6,6 +6,7 @@ import pytest
 
 from outlook_mcp.config import Config
 from outlook_mcp.errors import ReadOnlyError
+from outlook_mcp.tools.mail_read import RECEIVED_FLOOR
 from outlook_mcp.tools.mail_thread import copy_message, list_thread
 
 _CFG = Config(client_id="test")
@@ -77,6 +78,24 @@ class TestListThread:
         assert "conversationId eq 'conv123'" in qp.filter
         assert qp.orderby == ["receivedDateTime asc"]
         assert qp.top == 10
+
+    async def test_filter_leads_with_received_floor(self):
+        """The receivedDateTime clause MUST come first, or Graph rejects the
+        receivedDateTime $orderby with 400 InefficientFilter. Without this the
+        tool 400s on every call — assert position, not just presence.
+        """
+        mock_client = MagicMock()
+        mock_client.me.messages.get = AsyncMock(
+            return_value=MagicMock(value=[], odata_next_link=None)
+        )
+
+        await list_thread(mock_client, conversation_id="conv123", count=10)
+
+        call_kwargs = mock_client.me.messages.get.call_args
+        qp = call_kwargs.kwargs["request_configuration"].query_parameters
+        assert qp.filter == (
+            f"receivedDateTime ge {RECEIVED_FLOOR} and conversationId eq 'conv123'"
+        )
 
     async def test_list_thread_concise_strips_quoted_text(self):
         """concise=True drops everything from the first quoted-reply marker on."""

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,5 +1,7 @@
 """Tests for input validation — ported from olkcli patterns."""
 
+import itertools
+
 import pytest
 
 from outlook_mcp.validation import (
@@ -82,12 +84,6 @@ class TestKqlSanitization:
     def test_simple_query(self):
         assert sanitize_kql("budget report") == '"budget report"'
 
-    def test_strips_dangerous_chars(self):
-        result = sanitize_kql('from:boss" OR (hack)')
-        assert '"' not in result.strip('"')
-        assert "(" not in result.strip('"')
-        assert ")" not in result.strip('"')
-
     def test_preserves_alphanumeric(self):
         result = sanitize_kql("meeting notes 2026")
         assert "meeting" in result
@@ -95,9 +91,71 @@ class TestKqlSanitization:
         assert "2026" in result
 
     def test_strips_kql_operators(self):
+        # `&`, `|`, `!` are not Graph operators — the uppercase words are.
+        # The symbol forms silently zero out an otherwise-matching query.
         result = sanitize_kql("test & hack | evil")
         assert "&" not in result
         assert "|" not in result
+
+    # ── Property restrictions must survive (the #30 regression) ──
+
+    def test_preserves_property_restriction_colon(self):
+        """Stripping `:` turned every documented query into a 0-result phrase."""
+        assert sanitize_kql("subject:Unlock") == '"subject:Unlock"'
+
+    def test_preserves_all_documented_query_forms(self):
+        for query in (
+            "from:sarah@acme.com",
+            "hasattachment:true",
+            "received>=2026-01-01",
+            "subject:a AND subject:b",
+            "subject:a OR subject:b",
+            "NOT subject:a",
+        ):
+            assert sanitize_kql(query) == f'"{query}"', query
+
+    def test_preserves_grouping_parens(self):
+        assert sanitize_kql("subject:(a OR b)") == '"subject:(a OR b)"'
+
+    # ── Security: the two chars that must never survive ──
+
+    def test_strips_quote_that_would_neutralize_search(self):
+        """An embedded quote makes Graph silently discard $search and return
+        the whole mailbox — 200, no error. This is the real injection vector."""
+        result = sanitize_kql('Haverhill" OR "Wayfair')
+        assert result == '"Haverhill OR Wayfair"'
+        assert result.count('"') == 2
+
+    def test_strips_backslash_escape_metachar(self):
+        """`\\` is a real string-literal escape: `\\s` is a 400 and a trailing
+        `\\` escapes our own closing quote (400, unterminated literal)."""
+        assert sanitize_kql("back\\slash") == '"backslash"'
+        assert "\\" not in sanitize_kql("Acrisure\\")
+
+    def test_strips_bare_wildcard(self):
+        """Graph already prefix-matches (`subject:Amaz` == `subject:Amaz*`), so
+        `*` buys nothing. Allowing it would turn a bare `*` into a silent
+        whole-mailbox read; stripping it leaves an empty query we reject."""
+        with pytest.raises(ValueError, match="empty after sanitization"):
+            sanitize_kql("*")
+
+    def test_rejects_query_that_sanitizes_to_empty(self):
+        """$search="" is an opaque Graph BadRequest — fail clearly instead."""
+        for query in ('"""', "&|!", "   "):
+            with pytest.raises(ValueError, match="empty after sanitization"):
+                sanitize_kql(query)
+
+    def test_wrapper_invariant_holds_for_any_input(self):
+        """The invariant that actually prevents the vulnerability: whatever goes
+        in, exactly two quotes come out and no backslash survives."""
+        for combo in itertools.product('ab":\\()&|!*<>= ', repeat=3):
+            try:
+                result = sanitize_kql("".join(combo))
+            except ValueError:
+                continue  # rejected outright — also safe
+            assert result.count('"') == 2, result
+            assert "\\" not in result, result
+            assert result.startswith('"') and result.endswith('"'), result
 
 
 class TestFolderNameValidation:


### PR DESCRIPTION
Fixes #30, fixes #31 — plus a third bug of the same class that nobody had reported.

All three shipped in 1.12.0. All three are **structurally invisible to the test suite**, which mocks the Graph client and therefore cannot observe a query that Graph rejects or silently mis-evaluates. Each fix here was verified by replaying the code's *actual emitted query* against the live Graph API (read-only GETs).

## 1. `$orderby` / InefficientFilter — #31

`list_inbox` sets `$orderby=receivedDateTime desc` unconditionally. Graph requires an `$orderby` property to also appear in `$filter` **and to precede** the other filtered properties. Clause *order* is load-bearing — the same clauses with `receivedDateTime` second still 400.

Broken on every call in 1.12.0:

| call | before | after |
|---|---|---|
| `list_inbox(from_address=…)` | **400** | 200 |
| `list_inbox(classification="focused")` | **400** | 200 |
| `list_inbox(unread_only=True, from_address=…)` | **400** | 200 |
| `list_inbox(from_address=…, after=…)` | **400** | 200 |

Clauses are now emitted date-first, with a permissive `RECEIVED_FLOOR` prepended only when the caller supplies no `after`/`before`. They are still *validated* in signature order, so validation-error precedence is unchanged. Mailbox `$count` is identical with and without the floor.

**Considered and rejected:** dropping `$orderby` when `receivedDateTime` isn't filtered. Graph's implicit ordering follows whichever index served the filter — with `inferenceClassification` and no `$orderby` it returns **ascending**, so `list_inbox(classification="focused")` would have silently returned the *oldest* messages. A data-correctness regression with no error, varying by which filter the caller passed.

## 2. `outlook_list_thread` has never worked (unreported)

Same root cause: `$filter=conversationId eq '...'` with `$orderby=receivedDateTime asc` returns **400 InefficientFilter unconditionally**. Verified against six different real conversations — 6/6 failed before, 6/6 return 200 in correct ascending order after. This tool has been non-functional in every released version.

Not filed as a separate issue since the fix is the same shared constant.

## 3. `sanitize_kql` stripped `:` — #30

Every documented KQL property restriction was silently turned into a literal free-text phrase. `subject:Unlock` went out as `"subjectUnlock"` — HTTP 200, **zero results**, no error. The docstring's own example (`from:sarah@acme.com`) was broken.

The strip only has to protect the `$search="<value>"` string literal, so `:`, `(` and `)` are now allowed. Each remaining character has a measured reason:

| char | why it stays stripped |
|---|---|
| `"` | **the real vector** — an embedded quote makes Graph *silently discard* `$search` and return the whole mailbox (200, no error) |
| `\` | genuine escape metachar: `\s` is a 400, and a trailing `\` escapes our own closing quote |
| `*` | buys nothing — Graph already prefix-matches (`subject:Amaz` and `subject:Amaz*` both return 50) — and a bare `*` would become a silent whole-mailbox read where it is currently a loud 400 |
| `&` `\|` `!` | not operators; the symbol forms silently zero out an otherwise-matching query |

A query that sanitizes to empty now raises a clear `ValueError` instead of producing an opaque Graph `BadRequest`.

Note `sanitize_kql` is shared with `search_contacts`, so that path changes too and is covered.

Also corrects the `outlook_search_mail` docstring: `AND`/`OR`/`NOT` must be **uppercase** (lowercase `and` is matched as a literal term), and two terms with no operator between them *broaden* rather than narrow.

## Live verification

Read-only GETs, no writes. Every filter string below was captured from the patched code, not hand-written:

```
case               HTTP   filter
no filter          200    (none)
unread_only        200    receivedDateTime ge 1900-01-01T00:00:00Z and isRead eq false
from_address       200    receivedDateTime ge 1900-01-01T00:00:00Z and from/emailAddress/…
classification     200    receivedDateTime ge 1900-01-01T00:00:00Z and inferenceClassific…
after only         200    receivedDateTime ge 2026-01-01T00:00:00Z
before only        200    receivedDateTime le 2026-06-01T00:00:00Z
after+from         200    receivedDateTime ge 2026-01-01T00:00:00Z and from/emailAddress/…
list_thread        200    receivedDateTime ge 1900-01-01T00:00:00Z and conversationId eq …

CONTROL (pre-fix shape): 400  ← proves the fix is what changed it
```

KQL, including the hostile case checked against a no-`$search` baseline to prove it can't neutralize the query:

```
subject:michaelp        → "subject:michaelp"         200, 10 results
from:michaelp           → "from:michaelp"            200, 10 results
subject:x AND subject:zzzznomatch                    200,  0 results  (AND narrows)
subject:(x OR zzzznomatch)                           200, 10 results  (grouping works)
michaelp" OR "zzzznomatch → "michaelp OR zzzznomatch" 200, contained — no baseline leak
*                       → rejected with a clear ValueError
```

## Tests

**558 → 573 passing, 0 failures.** ruff clean.

The new assertions check clause **position** and exact emitted strings. The existing `assert "…" in qp.filter` substring checks are structurally incapable of catching a regression of any of this — the `$orderby` bug lived under them for multiple releases.

Two tests that encoded the old behavior were updated rather than added to:
- `tests/test_validation.py` — asserted parens were stripped
- `tests/test_contacts.py` — same

The highest-value new test is `test_wrapper_invariant_holds_for_any_input`: a small fuzz over `ab":\()&|!*<>=` asserting that whatever goes in, exactly two quotes come out and no backslash survives. That invariant is what actually prevents the vulnerability, and it holds independent of Graph's behavior.

## Follow-up worth considering

Everything above was found by probing the live API. The mock suite reported 558/558 green through all three bugs. `scripts/preflight.py` catches unsupported *endpoints* but treats a 400 as a non-blocking SKIP, so it would not have caught any of these either — they are all query-*shape* failures against endpoints that exist. A `@pytest.mark.live` tier, excluded from default CI, is the gap.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VcEKyvV7WUXvmWLyVwkDz
