### PR TITLE
docs: correct misattributed mailboxSettings quote, make the 403 hint reachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Two pure-code upgrades that make the same 57 tools cheaper and more recoverable 
 
 - **Concise mode** — pass `concise=True` to the five high-volume read tools (`outlook_list_inbox`, `outlook_read_message`, `outlook_search_mail`, `outlook_list_events`, `outlook_list_thread`) to drop bulky fields: full message bodies, per-event attendee lists, quoted prior-message text in threads, body previews/categories on inbox listings. Typical payload reduction ~10×. Default `concise=False` preserves the existing response shape — strict backward compat.
 
-- **Structured Graph errors** — every tool wraps msgraph SDK exceptions into `{code, message, action}` responses with operator-friendly recovery hints: re-auth on 401, ROADMAP pointer on 403/`ErrorAccessDenied` (known unsupported-endpoint dead-ends), re-list on 404/`ErrorItemNotFound`, back-off on 429, retry on 503. `OutlookMCPError` subclasses and validation errors pass through unchanged.
+- **Structured Graph errors** — every tool wraps msgraph SDK exceptions into `{code, message, action}` responses with operator-friendly recovery hints: re-auth on 401, a link to the repo's [ROADMAP dead-ends list](https://github.com/mpalermiti/outlook-mcp/blob/main/ROADMAP.md#investigated-and-not-viable) on 403/`ErrorAccessDenied`, re-list on 404/`ErrorItemNotFound`, back-off on 429, retry on 503. `OutlookMCPError` subclasses and validation errors pass through unchanged.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,7 +65,11 @@ For the population installing this from the MCP registry, not for Neo. stdio sta
 
 ## Investigated and not viable
 
-- **Mailbox settings (timezone, auto-reply, working hours, etc.)** — `/me/mailboxSettings/*` is documented as "Delegated (personal Microsoft account): Not supported" and verified to return `ErrorAccessDenied` on outlook.com mailboxes regardless of granted scopes. The resource is Exchange Online-only; consumer Outlook.com uses a different backend that Microsoft never bridged to Graph for this endpoint. Re-investigate if Microsoft publishes a consumer-account path for these settings.
+- **Mailbox settings (timezone, auto-reply, working hours, etc.)** — `/me/mailboxSettings/*` returns `403 ErrorAccessDenied` on outlook.com / hotmail.com / live.com mailboxes regardless of granted scopes. Verified against the live API when the 1.7.0 tools were yanked in 1.7.1, and re-verified 2026-09-03 (`/me/mailboxSettings`, `/timeZone`, `/automaticRepliesSetting`, `/workingHours` — all 403).
+
+  **Correction (2026-09-03):** this entry previously claimed the endpoint "is documented as `Delegated (personal Microsoft account): Not supported`". That quote is misattributed. The [Get](https://learn.microsoft.com/en-us/graph/api/user-get-mailboxsettings?view=graph-rest-1.0) and [Update](https://learn.microsoft.com/en-us/graph/api/user-update-mailboxsettings?view=graph-rest-1.0) mailboxSettings pages both *do* list personal Microsoft accounts as supported, and their generated permissions tables have been unchanged since 2023-10-27 — so they did not say "Not supported" when 1.7.1 shipped either. A neighbouring `MailboxSettings`-scoped page does carry that exact string for personal accounts ([Get workHoursAndLocations](https://learn.microsoft.com/en-us/graph/api/workhoursandlocationssetting-get?view=graph-rest-1.0), a different resource at `/me/settings/workHoursAndLocations`), which is the likely source of the mix-up. The empirical 403 is unaffected — it was always the real justification. Earlier prose also asserted the resource is "Exchange Online-only" and that consumer Outlook.com uses an unbridged backend; that is a plausible hypothesis, not something we verified.
+
+  **Do not treat the permissions table as evidence this works** — re-probe the live API before investing here.
 
 ---
 

--- a/src/outlook_mcp/errors.py
+++ b/src/outlook_mcp/errors.py
@@ -103,8 +103,9 @@ class GraphAPIError(OutlookMCPError):
 _HINT_TABLE: dict[tuple[int, str | None], str] = {
     (401, None): "Token may have expired — run `outlook-mcp auth` on the host.",
     (403, "ErrorAccessDenied"): (
-        "Endpoint may not be supported for this account type. "
-        "See ROADMAP 'Investigated and not viable' for known dead-ends."
+        "Endpoint may not be supported for this account type. See "
+        "https://github.com/mpalermiti/outlook-mcp/blob/main/ROADMAP.md"
+        "#investigated-and-not-viable for known dead-ends."
     ),
     (404, "ErrorItemNotFound"): (
         "Resource not found. The ID may be stale — re-list to get current IDs."

--- a/tests/test_error_wrapper.py
+++ b/tests/test_error_wrapper.py
@@ -45,7 +45,21 @@ def test_wrap_403_access_denied_references_roadmap():
     assert wrapped.status_code == 403
     assert wrapped.error_code == "ErrorAccessDenied"
     assert wrapped.action is not None
-    assert "ROADMAP" in wrapped.action
+    assert (
+        "https://github.com/mpalermiti/outlook-mcp/blob/main/ROADMAP.md"
+        "#investigated-and-not-viable" in wrapped.action
+    )
+
+
+def test_roadmap_anchor_heading_still_exists():
+    """The 403 hint deep-links to ROADMAP.md#investigated-and-not-viable.
+    ROADMAP.md is not shipped in the sdist or wheel, so the hint has to be a
+    URL — fail loudly here if the heading it points at is ever renamed.
+    """
+    from pathlib import Path
+
+    roadmap = Path(__file__).resolve().parents[1] / "ROADMAP.md"
+    assert "## Investigated and not viable" in roadmap.read_text(encoding="utf-8")
 
 
 def test_wrap_403_unknown_subcode_has_no_hint():


### PR DESCRIPTION
Two unrelated documentation defects found while reviewing #29.

## 1. `ROADMAP.md` — the mailboxSettings quote is misattributed

The dead-end entry claimed `/me/mailboxSettings/*` "is documented as `Delegated (personal Microsoft account): Not supported`".

That quote does not come from those pages. Both [Get mailboxSettings](https://learn.microsoft.com/en-us/graph/api/user-get-mailboxsettings?view=graph-rest-1.0) and [Update mailboxSettings](https://learn.microsoft.com/en-us/graph/api/user-update-mailboxsettings?view=graph-rest-1.0) list personal Microsoft accounts as **supported**, and the generated permissions tables behind them have been unchanged since **2023-10-27** — so they did not carry that string when 1.7.1 shipped in May 2026 either. This is a misquote, not a doc that later changed.

The string *does* exist on a neighbouring `MailboxSettings`-scoped page: [Get workHoursAndLocations](https://learn.microsoft.com/en-us/graph/api/workhoursandlocationssetting-get?view=graph-rest-1.0), a different resource at `/me/settings/workHoursAndLocations`, whose personal-MSA row reads `Not supported.` under `MailboxSettings.Read` / `MailboxSettings.ReadWrite`. That page covers *working hours* — a setting our own bullet names in its title — which makes it the likely source of the mix-up.

**The empirical justification is untouched and was always the real one.** Re-verified 2026-09-03 with read-only GETs:

```
GET /me/mailboxSettings                         → 403 ErrorAccessDenied
GET /me/mailboxSettings/timeZone                → 403 ErrorAccessDenied
GET /me/mailboxSettings/automaticRepliesSetting → 403 ErrorAccessDenied
GET /me/mailboxSettings/workingHours            → 403 ErrorAccessDenied
```

Corrected in place with a dated correction note rather than silently rewritten, so the record shows what changed and why. Also demotes the "Exchange Online-only / backend Microsoft never bridged" mechanism claim to a labelled hypothesis — it was asserted as fact but never verified, and I found no Microsoft source for it.

**One caveat I could not clear:** the cached token no longer carries `MailboxSettings.*` (those scopes were dropped in 1.7.1), so today's probe cannot re-prove the "regardless of granted scopes" part. It is suggestive though — a missing-scope denial from AAD is normally `Authorization_RequestDenied`, not the Exchange-family `ErrorAccessDenied` seen on all four paths.

### `CHANGELOG.md:148` is deliberately left alone

It repeats the same quote. I did **not** touch it: no released section in this changelog has ever been retroactively edited (`git log -p -- CHANGELOG.md` shows exactly two removed content lines in the file's whole history, both in an unreleased section), and corrections here have always shipped forward as new entries — 1.5.1 and 1.6.1 both did exactly that. A changelog records what was believed at the time; ROADMAP is the living document, so the correction belongs there. Worth a line in the next release notes if you want it recorded forward.

### Interaction with #29

#29 adds a new entry immediately after this one that currently draws a contrast against it ("unlike mailbox settings…", "just not flagged as unsupported in the docs themselves"). Both clauses assert that mailbox settings *is* flagged unsupported — which this change makes plainly false. The contributor has already been asked to drop the contrast. **No textual conflict** — #29 doesn't touch this line — but whichever merges second should confirm the framing still reads correctly.

## 2. `errors.py` — the 403 hint pointed at a file users don't have

The `(403, ErrorAccessDenied)` hint said *"See ROADMAP 'Investigated and not viable' for known dead-ends."* But `ROADMAP.md` ships in neither artifact — confirmed against the built 1.12.0 sdist and wheel, which contain only `src/outlook_mcp` plus README/LICENSE/pyproject. Anyone who `pip install`ed this and hit a 403 had nothing to open and no URL to follow.

Now a deep link to the heading on GitHub. `README.md:94` advertises the same behaviour and gets the matching link — README *is* shipped and renders on the PyPI project page, which is exactly where a reader is most likely to hit this and least likely to have a repo checkout.

Adds `test_roadmap_anchor_heading_still_exists` so renaming that heading fails CI rather than silently producing a dead anchor, and tightens the existing assertion from the substring `"ROADMAP"` — which is what let the pointer rot in the first place — to the full URL.

## Verification

558 → 559 passing, ruff clean. Hint renders as:

```
Endpoint may not be supported for this account type. See
https://github.com/mpalermiti/outlook-mcp/blob/main/ROADMAP.md#investigated-and-not-viable
for known dead-ends.
```

Independent of #32 — no file overlap, either order works.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VcEKyvV7WUXvmWLyVwkDz
