### PR TITLE
v1.13.1: pin mcp[cli]<2 — fresh installs have been broken since 2026-07-28

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,5 +52,6 @@ jobs:
           assert len(tools) == 62, f"expected 62 tools, got {len(tools)}"
           print(f"OK: server imports, {len(tools)} tools registered")
           PY
-      - name: CLI entrypoint must run
-        run: "$RUNNER_TEMP/fresh/bin/outlook-mcp" status || true
+      - name: CLI entrypoint must be wired and runnable
+        run: |
+          "$RUNNER_TEMP/fresh/bin/outlook-mcp" --help

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,43 @@ jobs:
       - run: uv sync --all-extras
       - run: uv run ruff check src/ tests/
       - run: uv run pytest --cov=outlook_mcp -v
+
+  # Guards the failure mode that shipped 1.12.0 and 1.13.0 broken for five weeks:
+  # `mcp[cli]` was declared with no upper bound, mcp 2.0.0 removed
+  # `mcp.server.fastmcp`, and every fresh `pip install` got a server that died on
+  # import. The `test` job above cannot see this — `uv sync` resolves through
+  # uv.lock, which pinned the old, working version.
+  #
+  # So this job deliberately ignores the lockfile and resolves like a real user,
+  # then imports the server from the built wheel. Any future upstream major that
+  # breaks us fails here instead of on someone's machine.
+  fresh-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - name: Build wheel
+        run: uv build
+      - name: Install from wheel with a fresh dependency resolve (no uv.lock)
+        run: |
+          uv venv "$RUNNER_TEMP/fresh"
+          uv pip install --python "$RUNNER_TEMP/fresh/bin/python" dist/*.whl
+      - name: Report resolved dependency versions
+        run: |
+          "$RUNNER_TEMP/fresh/bin/python" - <<'PY'
+          import importlib.metadata as md
+          for name in ("mcp", "msgraph-sdk", "azure-identity", "pydantic"):
+              print(f"{name}=={md.version(name)}")
+          PY
+      - name: Server must import and register its full tool surface
+        run: |
+          "$RUNNER_TEMP/fresh/bin/python" - <<'PY'
+          import outlook_mcp.server as s
+          tools = [a for a in dir(s) if a.startswith("outlook_")]
+          assert len(tools) == 62, f"expected 62 tools, got {len(tools)}"
+          print(f"OK: server imports, {len(tools)} tools registered")
+          PY
+      - name: CLI entrypoint must run
+        run: "$RUNNER_TEMP/fresh/bin/outlook-mcp" status || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to outlook-graph-mcp are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13.1] — 2026-09-04
+
+Hotfix. **Every fresh install since 2026-07-28 was dead on arrival** — this restores it. No code changes; one dependency bound and a CI job to make sure it cannot happen again.
+
+### Fixed
+
+- **`mcp[cli]` was declared with no upper bound, so new installs pulled an incompatible major.** `mcp` 2.0.0 (2026-07-28) removed `mcp.server.fastmcp` by design — it was renamed to `MCPServer`. `src/outlook_mcp/server.py` imports `from mcp.server.fastmcp import Context, FastMCP`, so a fresh `pip install outlook-graph-mcp` resolved `mcp` 2.1.1 and `outlook-mcp serve` exited 1 with:
+
+  ```
+  ModuleNotFoundError: No module named 'mcp.server.fastmcp'
+  ```
+
+  Now pinned to `mcp[cli]>=1.27,<2`, which resolves 1.29.1 and imports cleanly with all 62 tools.
+
+  This was **not** a 1.13.0 regression. 1.12.0 shipped 2026-07-18, ten days before `mcp` 2.0.0, and was broken by the same unbounded specifier the moment that release landed. Every install path — PyPI, `uvx`, ClawHub, the MCP registry — was affected for roughly five weeks. Migrating to the `mcp` 2.x `MCPServer` API is a separate, deliberate piece of work; this release only restores a working install.
+
+- **CI could not see it, which is why it lasted five weeks.** The test job runs `uv sync`, which resolves through `uv.lock` — and the lock pinned the old, working `mcp` 1.27.0. All 577 tests passed in 0.75s against a dependency set no new user would ever get. Same shape as the bugs fixed in 1.13.0: a green suite testing something other than what ships.
+
+### Added
+
+- **`fresh-install` CI job.** Builds the wheel, installs it into a clean venv with a **fresh dependency resolve that deliberately ignores `uv.lock`**, prints the resolved versions, then asserts the server imports and registers all 62 tools. This is the check that turns "an upstream major broke us" from a user-reported outage into a failed PR. It fails today on `main` without the pin — verified locally before shipping.
+
 ## [1.13.0] — 2026-09-04
 
 Correctness release. Three shipped bugs fixed, all of which were invisible to a fully green mock suite — including one tool that had never worked in any released version. Adds the live test tier that would have caught them. One new filter parameter; no new tools (still 62), no breaking changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "outlook-graph-mcp"
-version = "1.13.0"
+version = "1.13.1"
 description = "MCP server for Microsoft Outlook via Microsoft Graph API"
 readme = "README.md"
 license = "MIT"
@@ -21,7 +21,7 @@ classifiers = [
     "Topic :: Office/Business",
 ]
 dependencies = [
-    "mcp[cli]>=1.27",
+    "mcp[cli]>=1.27,<2",
     "msgraph-sdk>=1.55",
     "azure-identity>=1.25",
     "pydantic>=2.0",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.mpalermiti/outlook-mcp",
   "title": "Outlook MCP",
   "description": "Microsoft Outlook personal accounts: mail, calendar, contacts, to-do, drafts (62 tools).",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "websiteUrl": "https://github.com/mpalermiti/outlook-mcp",
   "repository": {
     "url": "https://github.com/mpalermiti/outlook-mcp",
@@ -14,7 +14,7 @@
     {
       "registryType": "pypi",
       "identifier": "outlook-graph-mcp",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "transport": {
         "type": "stdio"
       }

--- a/uv.lock
+++ b/uv.lock
@@ -1282,7 +1282,7 @@ wheels = [
 
 [[package]]
 name = "outlook-graph-mcp"
-version = "1.13.0"
+version = "1.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "azure-identity" },
@@ -1309,7 +1309,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "azure-identity", specifier = ">=1.25" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.27" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.27,<2" },
     { name = "msgraph-sdk", specifier = ">=1.55" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },


### PR DESCRIPTION
**Every fresh install of this package has been broken since 2026-07-28.** This restores it.

## The break

`pyproject.toml` declared `mcp[cli]>=1.27` with no upper bound. `mcp` 2.0.0 shipped 2026-07-28 and removed `mcp.server.fastmcp` by design — it was renamed to `MCPServer`. `src/outlook_mcp/server.py:11` imports `from mcp.server.fastmcp import Context, FastMCP`.

Reproduced end to end against the published package:

```
$ uv pip install outlook-graph-mcp
$ python -c "import importlib.metadata as md; print(md.version('mcp'))"
2.1.1

$ outlook-mcp serve
ModuleNotFoundError: No module named 'mcp.server.fastmcp'. This is mcp 2.x,
where FastMCP was renamed to MCPServer ... or pin 'mcp<2' to keep running v1 code.
exit 1
```

Pinned to `mcp[cli]>=1.27,<2`. Verified: resolves 1.29.1, imports cleanly, all 62 tools register.

## Scope — this is not a 1.13.0 regression

1.12.0 shipped 2026-07-18, **ten days before** `mcp` 2.0.0, and broke the moment that landed. Every install path — PyPI, `uvx`, ClawHub, the MCP registry — has been dead on arrival for roughly five weeks. Today's 1.13.0 neither caused nor fixed it.

Migrating to the `mcp` 2.x `MCPServer` API is separate, deliberate work. This release only restores a working install.

## Why CI missed it for five weeks

The `test` job runs `uv sync`, which resolves through `uv.lock` — and the lock pinned the old, working `mcp` 1.27.0. **577 tests passed in 0.75s against a dependency set no new user could ever get.**

That is the same shape as the three bugs fixed in 1.13.0 this morning: a fully green suite exercising something other than what ships. There the mock hid Graph's real behavior; here the lockfile hid the real dependency resolution.

## The guard

New `fresh-install` CI job. Builds the wheel, installs it into a clean venv with a dependency resolve that **deliberately ignores `uv.lock`**, prints what it resolved, then asserts the server imports and registers all 62 tools.

Verified in both directions locally — a guard that only passes proves nothing:

```
published 1.13.0 wheel (unpinned)  →  ModuleNotFoundError  ← job would FAIL
this build (pinned <2)             →  mcp==1.29.1, 62 tools registered  ← PASSES
```

It also prints the resolved versions of all four direct dependencies on every run, so the next upstream major shows up as a failed PR rather than a user-reported outage.

## Verification

```
fresh resolve      mcp==1.29.1  msgraph-sdk==1.62.0  azure-identity==1.25.3  pydantic==2.13.5
                   server imports, 62 tools registered
preflight.py       13/13 endpoints OK — "Safe to tag"
pytest (unit)      577 passed
ruff               All checks passed!
```

No source files changed — `git diff main -- src/` is empty. This is a dependency bound, version bump, changelog and CI job, so 1.13.0's live-tier and preflight results still hold. Re-ran the gates anyway.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VcEKyvV7WUXvmWLyVwkDz
