### PR TITLE
ci: run an install canary on a clock, not on a commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,14 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  # Mondays 14:00 UTC (~7am Pacific). See `published-install` below for why.
+  schedule:
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
 jobs:
   test:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,6 +32,7 @@ jobs:
   # then imports the server from the built wheel. Any future upstream major that
   # breaks us fails here instead of on someone's machine.
   fresh-install:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -55,3 +63,45 @@ jobs:
       - name: CLI entrypoint must be wired and runnable
         run: |
           "$RUNNER_TEMP/fresh/bin/outlook-mcp" --help
+
+  # Answers the question that went unanswered for five weeks: can a new user
+  # install the *published* package today and get a server that starts?
+  #
+  # `fresh-install` above resolves dependencies like a real user, but it only
+  # runs on push — so it structurally cannot catch what actually bit us. Nothing
+  # was pushed. `mcp` 2.0.0 landed 2026-07-28, ten days after the last commit,
+  # and every install from PyPI was dead on arrival until 2026-09-03. The repo
+  # was byte-identical on both sides of the break.
+  #
+  # So this one runs on a clock instead of on a commit, and installs from PyPI
+  # rather than the working tree — which also covers a bad publish, not just a
+  # breaking upstream release.
+  published-install:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+      - name: Install the latest published release from PyPI
+        run: |
+          uv venv "$RUNNER_TEMP/pypi"
+          uv pip install --python "$RUNNER_TEMP/pypi/bin/python" outlook-graph-mcp
+      - name: Report what a new user actually gets
+        run: |
+          "$RUNNER_TEMP/pypi/bin/python" - <<'PY'
+          import importlib.metadata as md
+          for name in ("outlook-graph-mcp", "mcp", "msgraph-sdk", "azure-identity", "pydantic"):
+              print(f"{name}=={md.version(name)}")
+          PY
+      - name: Published server must import and register its full tool surface
+        run: |
+          "$RUNNER_TEMP/pypi/bin/python" - <<'PY'
+          import outlook_mcp.server as s
+          tools = [a for a in dir(s) if a.startswith("outlook_")]
+          assert len(tools) == 62, f"expected 62 tools, got {len(tools)}"
+          print(f"OK: published package imports, {len(tools)} tools registered")
+          PY
+      - name: CLI entrypoint must be wired and runnable
+        run: |
+          "$RUNNER_TEMP/pypi/bin/outlook-mcp" --help


### PR DESCRIPTION
Closes the one structural gap left by 1.13.1.

## The problem

The five-week outage had a property none of our checks can see: **the repo did not change.** `mcp` 2.0.0 landed 2026-07-28, ten days after the last commit, and every install from PyPI was dead until 2026-09-03. The working tree was byte-identical on both sides of the break.

`fresh-install` (added in 1.13.1) resolves dependencies like a real user — the right check. But it triggers on push, so it would have sat idle through the entire outage. A guard that only arms when someone is already working cannot catch *"the world changed while nobody was working."*

## The change

Adds a `published-install` job on a weekly schedule (Mondays 14:00 UTC) plus manual dispatch. Two deliberate differences from `fresh-install`:

1. **It runs on a clock**, so quiet periods are covered — that's the whole point.
2. **It installs `outlook-graph-mcp` from PyPI** rather than building the working tree. So it also catches a broken *publish*, not just a breaking upstream release. It asks the actual user-facing question: can someone install this today and get a server that starts?

It verifies the published package imports, registers all 62 tools, and that the `outlook-mcp` CLI runs — and prints the resolved versions of `mcp`, `msgraph-sdk`, `azure-identity` and `pydantic`, so a future break comes with the diagnosis attached.

`test` and `fresh-install` are gated off the schedule (`if: github.event_name != 'schedule'`). They answer "did our code break itself," which cannot change without a commit; re-running them weekly is noise. On push and PR, nothing about today's behavior changes.

## Notes

- **No version bump** — CI-only, no packaged artifact changes.
- **Weekly caps exposure at ~7 days.** Daily is a one-character change (`* * *` in place of `* * 1`) if you want it tighter; failures are the only thing that notifies, so daily costs no attention.
- **The one gap this cannot close itself:** GitHub disables scheduled workflows after 60 days of repo inactivity. It emails a warning first and re-enabling is one click — but it's worth knowing, because prolonged quiet is exactly the condition this job exists to cover.
- The 62-tool assertion is hardcoded, matching `fresh-install`. It needs updating alongside the existing one whenever the tool count changes.
- This job cannot pass until a working version is on PyPI. 1.13.1 is, so it goes green immediately.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nryiJ3wZ3NbAgsrMdzQvo