### PR TITLE
ci: make tagging a release publish everything, with no stored credentials

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,122 @@
+name: Publish
+
+# Tagging a release is the whole release.
+#
+# This publishes to PyPI and the MCP registry with no stored credentials. Both
+# verify us through GitHub's OIDC: GitHub vouches for this specific workflow at
+# run time, so there is no token to keep, rotate, or leak — and no five-minute
+# registry login to race by hand.
+#
+# What this does NOT replace: the live-Graph smoke test (RELEASING.md step 1).
+# Those need real credentials and cannot run here. Run them BEFORE you tag —
+# a green offline suite is exactly what shipped 1.13.0 and 1.13.1 broken.
+#
+# ClawHub has no OIDC equivalent and stays manual:
+#   clawhub publish "$(pwd)" --version X.Y.Z --tags latest --changelog "..."
+#
+# One-time PyPI setup is required before this can work. See RELEASING.md.
+
+on:
+  release:
+    types: [published]
+  # Manual re-run — safe to repeat. PyPI uploads are skipped if already present,
+  # so a dispatch after a partial failure retries only what did not finish.
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # lets GitHub vouch for this job to PyPI and the registry
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.13"
+
+      # The version lives in three places and they must agree. A mismatch means
+      # a half-updated release — better to stop before anything is published.
+      - name: Version lockstep check
+        id: version
+        run: |
+          PY_VERSION=$(grep -m1 '^version = ' pyproject.toml | cut -d'"' -f2)
+          if [ -z "$PY_VERSION" ]; then
+            echo "::error::could not read version from pyproject.toml"
+            exit 1
+          fi
+          SJ_COUNT=$(grep -c "\"version\": \"$PY_VERSION\"" server.json || true)
+          if [ "$SJ_COUNT" -ne 2 ]; then
+            echo "::error::server.json must carry version $PY_VERSION in both fields (found $SJ_COUNT)"
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+            if [ "$PY_VERSION" != "$TAG_VERSION" ]; then
+              echo "::error::tag v$TAG_VERSION does not match pyproject version $PY_VERSION"
+              exit 1
+            fi
+          fi
+          echo "version=$PY_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing $PY_VERSION"
+
+      - name: Tests and lint
+        run: |
+          uv sync --all-extras
+          uv run pytest -q
+          uv run ruff check src/ tests/
+
+      - name: Build
+        run: uv build
+
+      # No token. PyPI trusted publishing verifies this repo and workflow via
+      # OIDC. --check-url makes a re-run skip files already uploaded instead of
+      # failing on a duplicate.
+      - name: Publish to PyPI
+        run: |
+          uv publish \
+            --trusted-publishing always \
+            --check-url https://pypi.org/simple/outlook-graph-mcp/
+
+      # The registry refuses a version it cannot find on PyPI, and PyPI's index
+      # lags its own upload by up to a couple of minutes. Wait rather than race.
+      - name: Wait for PyPI to serve the new version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          for i in $(seq 1 30); do
+            CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+              "https://pypi.org/pypi/outlook-graph-mcp/$VERSION/json")
+            if [ "$CODE" = "200" ]; then
+              echo "PyPI is serving $VERSION"
+              exit 0
+            fi
+            echo "attempt $i: PyPI returned $CODE — waiting 10s"
+            sleep 10
+          done
+          echo "::error::PyPI never served $VERSION after 5 minutes"
+          exit 1
+
+      - name: Install mcp-publisher
+        run: |
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+
+      # Replaces `mcp-publisher login github`, which needs a browser and issues
+      # a token that expires five minutes later.
+      - name: Publish to the MCP registry
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
+
+      - name: Summary
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          {
+            echo "### Published $VERSION"
+            echo ""
+            echo "- PyPI: https://pypi.org/project/outlook-graph-mcp/$VERSION/"
+            echo "- MCP registry: io.github.mpalermiti/outlook-mcp"
+            echo ""
+            echo "Still manual: \`clawhub publish \"\$(pwd)\" --version $VERSION --tags latest\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -76,21 +76,34 @@ gh pr merge <num> --rebase --delete-branch
 git checkout main && git pull --ff-only
 ```
 
-## 5. Tag + GitHub release
+## 5. Tag + GitHub release — this publishes everything
 
 ```bash
 gh release create vX.Y.Z --target main --title "vX.Y.Z" --notes "<changelog body>"
 ```
 
-## 6. Publish
+Publishing the release triggers `.github/workflows/publish.yml`, which re-checks the version lockstep, runs tests and lint, builds, publishes to **PyPI**, waits for PyPI's index to catch up, then publishes to the **MCP registry**. Both authenticate through GitHub OIDC — no stored tokens, and no five-minute registry login to race by hand.
+
+Watch it:
 
 ```bash
-uv build
-uv publish dist/outlook_graph_mcp-X.Y.Z-py3-none-any.whl dist/outlook_graph_mcp-X.Y.Z.tar.gz
+gh run watch
+```
 
+If it fails partway, re-run it. Uploads already on PyPI are skipped, so a dispatch retries only what didn't finish:
+
+```bash
+gh workflow run publish.yml
+```
+
+> The workflow deliberately does **not** run the live tier — those need real credentials. Step 1 is still yours, and still the step that matters: a green offline suite is exactly what shipped 1.13.0 and 1.13.1 broken.
+
+## 6. Publish to ClawHub (the one manual channel)
+
+ClawHub has no OIDC equivalent, so it stays hand-run:
+
+```bash
 clawhub publish "$(pwd)" --version X.Y.Z --tags latest --changelog "<one-liner>"
-
-mcp-publisher publish   # may need `mcp-publisher login github` if JWT expired
 ```
 
 ## 7. Update GitHub About
@@ -112,3 +125,20 @@ And confirm the MCP registry shows the new version as `(latest)`:
 ```bash
 curl -s 'https://registry.modelcontextprotocol.io/v0/servers?search=mpalermiti&limit=20' | python3 -c "import json,sys; [print(s['server'].get('version'), '(latest)' if s.get('_meta',{}).get('io.modelcontextprotocol.registry/official',{}).get('isLatest') else '') for s in json.load(sys.stdin).get('servers', [])]"
 ```
+
+
+## Appendix — one-time PyPI trusted publisher setup
+
+Step 5 uploads to PyPI without a token by using PyPI's *trusted publishing*: PyPI verifies the workflow through GitHub OIDC rather than a stored API token. It has to be registered once in PyPI's web UI — it cannot be scripted:
+
+1. Go to <https://pypi.org/manage/project/outlook-graph-mcp/settings/publishing/>
+2. Add a **GitHub** publisher with exactly:
+
+   | Field | Value |
+   | --- | --- |
+   | Owner | `mpalermiti` |
+   | Repository | `outlook-mcp` |
+   | Workflow name | `publish.yml` |
+   | Environment | *(leave blank)* |
+
+Until this is saved, the workflow's PyPI step fails with an OIDC/trusted-publishing error. Once saved, `UV_PUBLISH_TOKEN` is no longer needed and can be dropped from the shell environment.


### PR DESCRIPTION
Removes the last manual step in the release, and the last long-lived publishing credential.

## What changes

Today you publish to PyPI by hand with a stored token, then log in to the MCP registry through a browser and race a **5-minute** token to publish. That race is why the registry has repeatedly lagged the other channels.

After this: **you publish a GitHub release, and that's the whole release.** The workflow checks versions, runs tests and lint, builds, uploads to PyPI, waits for PyPI's index, and publishes to the registry — unattended.

## How it authenticates without secrets

Both PyPI and the MCP registry accept **GitHub OIDC**. GitHub mints a short-lived signed statement at run time — *"this job is running in `mpalermiti/outlook-mcp`, workflow `publish.yml`"* — and each service verifies that signature. Since the registry namespace is `io.github.mpalermiti`, ownership follows directly from the repo owner in that statement.

No secret is stored, rotated, or exposed. `permissions: id-token: write` is the entire configuration.

## Design notes

- **Version lockstep is enforced in CI** — `pyproject.toml`, both `server.json` fields, and the tag must agree. A half-updated release stops before anything is published. Logic tested against the real files, including the failure case.
- **PyPI index lag is waited on, not raced.** The registry rejects a version it can't find on PyPI, and PyPI's index trails its own upload. I hit exactly this during the 1.14.0 release — a fresh install kept resolving 1.13.1 for minutes after upload. The workflow polls for up to 5 minutes.
- **Re-runs are safe.** `uv publish --check-url` skips files already uploaded, so `gh workflow run publish.yml` retries only what didn't finish.
- **The live tier is deliberately not run here.** It needs real Graph credentials. RELEASING.md step 1 stays a human gate — a green offline suite is exactly what shipped 1.13.0 and 1.13.1 broken, and automating past that would repeat the mistake.
- **ClawHub stays manual** — no OIDC equivalent exists.

## ⚠️ One-time setup required before this works

The PyPI step will fail until a trusted publisher is registered. This is web-UI only and can't be scripted:

<https://pypi.org/manage/project/outlook-graph-mcp/settings/publishing/>

| Field | Value |
| --- | --- |
| Owner | `mpalermiti` |
| Repository | `outlook-mcp` |
| Workflow name | `publish.yml` |
| Environment | *(leave blank)* |

Once saved, `UV_PUBLISH_TOKEN` is no longer needed and can be dropped from your shell environment. Documented in the RELEASING.md appendix.

## Verified

YAML parses; triggers, permissions and step order confirmed. The version-check shell logic was run against the real `pyproject.toml` and `server.json` — passes on 1.14.0, correctly fails on a mismatched version, and parses `refs/tags/v1.14.0` → `1.14.0`.

Not verifiable before merge: the workflow itself can't run until it's on the default branch, and the PyPI step can't succeed until the trusted publisher exists. First real exercise is the 1.15.0 release.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nryiJ3wZ3NbAgsrMdzQvo