### PR TITLE
ci: make the registry publish idempotent so retries stay green

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,7 +107,21 @@ jobs:
       - name: Publish to the MCP registry
         run: |
           ./mcp-publisher login github-oidc
-          ./mcp-publisher publish
+          # The registry rejects a duplicate version, which would turn the
+          # documented retry (`gh workflow run publish.yml`) red after a run
+          # that already succeeded. Treat "already published" as done — the
+          # same idempotence --check-url gives the PyPI step above.
+          set +e
+          OUT=$(./mcp-publisher publish 2>&1)
+          CODE=$?
+          echo "$OUT"
+          if [ "$CODE" -ne 0 ]; then
+            if echo "$OUT" | grep -q "cannot publish duplicate version"; then
+              echo "Already in the registry at this version — nothing to do."
+              exit 0
+            fi
+            exit "$CODE"
+          fi
 
       - name: Summary
         run: |


### PR DESCRIPTION
Follow-up to #38, found by actually running it.

## What the smoke test proved

I dispatched the new workflow against the already-published 1.14.0. Both halves of the credential-free setup work:

- **PyPI trusted publishing** — authenticated against `upload.pypi.org` and the step passed. The one-time setup is live.
- **Registry OIDC** — `Logging in with github-oidc... ✓ Successfully logged in`. No browser, no 5-minute token.

## What it exposed

The registry then refused:

```
cannot publish duplicate version
```

Correct behavior, and a non-issue on a real release where the version is new. But it breaks the retry path #38 documents: after a run that *fully succeeded*, `gh workflow run publish.yml` goes red. A publish workflow that goes red when everything is fine is worse than no retry path — it teaches you to ignore the signal.

## Fix

Treat "already published at this version" as success — the same idempotence `uv publish --check-url` already gives the PyPI step. Every other publish failure still fails the job.

Verified both branches of the condition: the duplicate message exits 0, anything else propagates the original exit code.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nryiJ3wZ3NbAgsrMdzQvo