### PR TITLE
docs: bring the docs in line with 1.14.0 and record two operational facts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
   # So this one runs on a clock instead of on a commit, and installs from PyPI
   # rather than the working tree — which also covers a bad publish, not just a
   # breaking upstream release.
+  #
+  # CAVEAT: GitHub disables scheduled workflows after 60 days of repository
+  # inactivity — i.e. a long enough quiet period switches off the guard that
+  # exists to cover quiet periods. GitHub emails a warning first and re-enabling
+  # is one click, so don't dismiss that mail as noise.
   published-install:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ MCP server for Microsoft Outlook personal accounts (Outlook.com/Hotmail) via Mic
 Works with any MCP client (OpenClaw, Claude Code, Cursor).
 
 ## Tech Stack
-- Python 3.10+, FastMCP, msgraph-sdk, azure-identity, Pydantic v2
+- Python 3.10+, MCP Python SDK 2.x (`MCPServer`), msgraph-sdk, azure-identity, Pydantic v2
 - Package manager: uv
 - Testing: pytest + pytest-asyncio
 
@@ -18,8 +18,15 @@ Works with any MCP client (OpenClaw, Claude Code, Cursor).
 - `uv run outlook-mcp` — start server (stdio)
 - `uv run python scripts/preflight.py` — pre-release Graph smoke test (must pass before tagging; see `RELEASING.md`)
 
+## Releasing
+Publishing is automated — do **not** run `uv publish` or `mcp-publisher` by hand.
+Publishing a GitHub release triggers `.github/workflows/publish.yml`, which re-checks
+the version lockstep, runs tests and lint, builds, and publishes to PyPI and the MCP
+registry via GitHub OIDC (no stored credentials). Full process in `RELEASING.md`.
+Still manual by design: the live tier (run it *before* tagging) and ClawHub.
+
 ## Architecture
-- `src/outlook_mcp/server.py` — FastMCP entry point, lifespan context
+- `src/outlook_mcp/server.py` — `MCPServer` entry point, lifespan context
 - `src/outlook_mcp/auth.py` — Device code OAuth2 via azure-identity
 - `src/outlook_mcp/graph.py` — Graph client factory
 - `src/outlook_mcp/config.py` — Config file management (~/.outlook-mcp/)
@@ -57,3 +64,4 @@ Works with any MCP client (OpenClaw, Claude Code, Cursor).
 - Errors: raise OutlookMCPError subclasses, never return error dicts
 - Datetimes: UTC in responses, config timezone for input interpretation
 - Delete: soft delete (move to Deleted Items) by default
+- Dependency bounds: an unbounded requirement can break every fresh install without a single commit. `mcp[cli]` with no upper bound shipped a package that could not be installed for five weeks (2026-07-28 → 09-03) while CI stayed green — `uv sync` resolves through `uv.lock`, so the `test` job never sees what a new user actually gets. The `fresh-install` (per push) and `published-install` (weekly cron) jobs in `ci.yml` are the guard against this class; keep them working

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,8 +51,8 @@ For the population installing this from the MCP registry, not for Neo. stdio sta
 ### Tier 2 — deferred (hosting- or client-gated; revisit when the precondition lands)
 - **Change-notification webhooks** as the delta trigger (near-real-time, avoids polling/throttling) — needs a public HTTPS endpoint; N/A for stdio/local. Rich-mode notifications carry the changed object inline (a token lever) but need an encryption cert. Recommended end-state is delta-tokens **+** webhooks.
 - **Code-execution-with-MCP / progressive tool disclosure** — needs a client that presents tools as a sandboxed code API; still theoretical for the single-personal-agent case.
-- **Structured output schemas** — typed Pydantic returns → `outputSchema` / `structuredContent`. Gate on confirming the target client consumes it (else pure cost).
-- **FastMCP 2.x migration** for middleware/tags — its `ResponseCachingMiddleware` conflicts with the no-local-caching principle; the Tier-0 selector delivers the tag benefit without the dependency swap.
+- **Structured output schemas** — typed Pydantic returns → `outputSchema` / `structuredContent`. Gate on confirming the target client consumes it (else pure cost). *Cheaper since 1.14.0: `structured_output` is a first-class kwarg on `MCPServer.tool()` in the 2.x SDK. Verified 2026-09-04 over a real stdio session that we currently emit `TextContent` only and no `structuredContent`, so adopting this stays fully opt-in.*
+- **FastMCP 2.x migration** for middleware/tags — *note: this means jlowin's separate `fastmcp` package, NOT the official `mcp` SDK 2.x, which this project already runs as of 1.14.0.* Its `ResponseCachingMiddleware` conflicts with the no-local-caching principle; the Tier-0 selector delivers the tag benefit without the dependency swap.
 
 ---
 


### PR DESCRIPTION
Post-release cleanup. No behavior changes — this stops the docs from telling a future reader something that is no longer true.

## Stale after the migration

**`CLAUDE.md`** still described the tech stack and entry point as **FastMCP**. That module doesn't exist anymore; it's `MCPServer`. Anyone (human or agent) orienting from this file would have started from a wrong mental model.

**`ROADMAP.md:55`** lists a Tier-2 *"FastMCP 2.x migration"*. That means **jlowin's separate `fastmcp` package** — not the official `mcp` SDK 2.x, which we now run as of 1.14.0. Post-migration those two read as the same thing. This is a genuine trap: someone could reasonably mark it done, or redo work we just finished. Now called out explicitly.

## Facts that lived nowhere durable

**The dependency-bounds lesson** → `CLAUDE.md` Conventions. An unbounded requirement broke every fresh install for five weeks without a single commit, while CI stayed green — because `uv sync` resolves through `uv.lock`, so the `test` job never sees what a new user gets. That's the most expensive thing this project learned this year and it only existed in a CHANGELOG entry nobody re-reads.

**The 60-day scheduled-workflow disable** → `ci.yml`, next to the cron. GitHub switches off scheduled workflows after 60 days of repo inactivity — meaning a long enough quiet period disables the guard whose entire purpose is covering quiet periods. It was in a PR description, which is exactly where operational caveats go to die.

**Structured output evidence** → `ROADMAP.md` Tier 2. The 2.x SDK makes `structured_output` a first-class `.tool()` kwarg, and a real stdio client session on 2026-09-04 confirmed we currently emit `TextContent` only with no `structuredContent`. That decision now starts from measurement instead of assumption.

## Also added

A **Releasing** section in `CLAUDE.md`. Publishing is automated now, and the failure mode worth preventing is someone reflexively running `uv publish` or `mcp-publisher` by hand out of habit — which would work, badly, and bypass the version-lockstep check.

Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014nryiJ3wZ3NbAgsrMdzQvo